### PR TITLE
Changed all instances of waveportalContract to wavePortalContract

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
@@ -24,9 +24,9 @@ const wave = async () => {
       if (ethereum) {
         const provider = new ethers.providers.Web3Provider(ethereum);
         const signer = provider.getSigner();
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
+        const wavePortalContract = new ethers.Contract(contractAddress, contractABI, signer);
 
-        let count = await waveportalContract.getTotalWaves();
+        let count = await wavePortalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
       } else {
         console.log("Ethereum object doesn't exist!");
@@ -152,18 +152,18 @@ const wave = async () => {
         /*
         * You're using contractABI here
         */
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
+        const wavePortalContract = new ethers.Contract(contractAddress, contractABI, signer);
 
-        let count = await waveportalContract.getTotalWaves();
+        let count = await wavePortalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
 
-        const waveTxn = await waveportalContract.wave();
+        const waveTxn = await wavePortalContract.wave();
         console.log("Mining...", waveTxn.hash);
 
         await waveTxn.wait();
         console.log("Mined -- ", waveTxn.hash);
 
-        count = await waveportalContract.getTotalWaves();
+        count = await wavePortalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
       } else {
         console.log("Ethereum object doesn't exist!");
@@ -191,21 +191,21 @@ const wave = async () => {
       if (ethereum) {
         const provider = new ethers.providers.Web3Provider(ethereum);
         const signer = provider.getSigner();
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
+        const wavePortalContract = new ethers.Contract(contractAddress, contractABI, signer);
 
-        let count = await waveportalContract.getTotalWaves();
+        let count = await wavePortalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
 
         /*
         * Execute the actual wave from your smart contract
         */
-        const waveTxn = await waveportalContract.wave();
+        const waveTxn = await wavePortalContract.wave();
         console.log("Mining...", waveTxn.hash);
 
         await waveTxn.wait();
         console.log("Mined -- ", waveTxn.hash);
 
-        count = await waveportalContract.getTotalWaves();
+        count = await wavePortalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
       } else {
         console.log("Ethereum object doesn't exist!");

--- a/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
+++ b/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
@@ -194,12 +194,12 @@ const [currentAccount, setCurrentAccount] = useState("");
       if (ethereum) {
         const provider = new ethers.providers.Web3Provider(ethereum);
         const signer = provider.getSigner();
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
+        const wavePortalContract = new ethers.Contract(contractAddress, contractABI, signer);
 
         /*
          * Call the getAllWaves method from your Smart Contract
          */
-        const waves = await waveportalContract.getAllWaves();
+        const waves = await wavePortalContract.getAllWaves();
         
 
         /*
@@ -277,7 +277,7 @@ Basically, I just go through `allWaves` and create new divs for every single wav
 So, in `App.js`, our `wave()` function no longer works! If we try to wave it'll give us an error because it's expecting a message to be sent now with it now! For now, you can fix this by hardcoding a message like:
 
 ```
-const waveTxn = await waveportalContract.wave("this is a message")
+const waveTxn = await wavePortalContract.wave("this is a message")
 ```
 
 I'll leave this up you: figure out how to add a textbox that lets users add their own custom message they can send to the wave function :).

--- a/Solidity_And_Smart_Contracts/Section_5/Lesson_2_Finalize_Celebrate.md
+++ b/Solidity_And_Smart_Contracts/Section_5/Lesson_2_Finalize_Celebrate.md
@@ -29,7 +29,7 @@ Estimating gas is a hard problem and an easy workaround for this (so our users d
 On App.js, I changed the line that sends the wave to 
 
 ```solidity
-waveportalContract.wave(message, { gasLimit: 300000 })
+wavePortalContract.wave(message, { gasLimit: 300000 })
 ```
 
 What this does is make the user pay a set amount of gas of 300,000. And, if they don't use all of it in the transaction they'll automatically be refunded.


### PR DESCRIPTION
Changed all instances of waveportalContract to wavePortalContract.

Please check the comments to the following gists and update your gist if required:

https://gist.github.com/adilanchian/71890bf4fcd8f78e94c77cf694b24659

https://gist.github.com/adilanchian/236fe9f3a56b73751060800cae3a780d

https://gist.github.com/adilanchian/93fbd2e06b3b5d3acb99b5723cebd925

Also potentially you need to change the replit screenshot on line 63 in Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md 

This means you can close [PR#76](https://github.com/buildspace/buildspace-projects/pull/76)