### PR TITLE
Remove waving code that was introduced too soon

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_4_Call_Deployed_Contract.md
@@ -156,15 +156,6 @@ const wave = async () => {
 
         let count = await wavePortalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
-
-        const waveTxn = await wavePortalContract.wave();
-        console.log("Mining...", waveTxn.hash);
-
-        await waveTxn.wait();
-        console.log("Mined -- ", waveTxn.hash);
-
-        count = await wavePortalContract.getTotalWaves();
-        console.log("Retrieved total wave count...", count.toNumber());
       } else {
         console.log("Ethereum object doesn't exist!");
       }


### PR DESCRIPTION
This change removes the waving code from the `Getting ABI File Content` section.

### Rationale

The `Getting ABI File Content` section includes code for waving (i.e. writing data to the blockchain). This section should not contain any waving code because the waving code isn't introduced until the next section, `Writing data`.

