### PR TITLE
Remove unnecessary text from Section 1 Lesson 1

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_2_Write_Your_First_Smart_Contract.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_2_Write_Your_First_Smart_Contract.md
@@ -53,7 +53,7 @@ contract WavePortal {
 }
 ```
 
-So, smart contracts kinda look like a `class` in other languages, if you've ever seen those! Once we initialize this contract for the first time, that constructor will run and print out that line. Please make that line say whatever you want :)! Call the variable whatever you want.
+So, smart contracts kinda look like a `class` in other languages, if you've ever seen those! Once we initialize this contract for the first time, that constructor will run and print out that line. Please make that line say whatever you want :)!
 
 Let's run this and see what we get!
 


### PR DESCRIPTION
The line `Call the variable whatever you want.` should be removed since there is no variable in the Solidity contract yet.  If it was referring to the contract name itself `WavePortal`, then changing that name would cause issues with the hre run script in the next lesson.