### PR TITLE
Replace let by const when it was possible in the first section

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_4_Store_Data_On_Smart_Contract.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_4_Store_Data_On_Smart_Contract.md
@@ -75,7 +75,7 @@ const main = async () => {
   let waveCount;
   waveCount = await waveContract.getTotalWaves();
   
-  let waveTxn = await waveContract.wave();
+  const waveTxn = await waveContract.wave();
   await waveTxn.wait();
 
   waveCount = await waveContract.getTotalWaves();
@@ -118,7 +118,7 @@ The last thing I added was this:
 let waveCount;
 waveCount = await waveContract.getTotalWaves();
 
-let waveTxn = await waveContract.wave();
+const waveTxn = await waveContract.wave();
 await waveTxn.wait();
 
 waveCount = await waveContract.getTotalWaves();


### PR DESCRIPTION
### Fix let by const

#### Description:

In Section 1, there is a use of let which should be replaced by const.
This pull request is resolving that mistake.
```javascript
const main = async () => {
  const [owner, randomPerson] = await hre.ethers.getSigners();
  const waveContractFactory = await hre.ethers.getContractFactory('WavePortal');
  const waveContract = await waveContractFactory.deploy();
  await waveContract.deployed();

  console.log("Contract deployed to:", waveContract.address);
  console.log("Contract deployed by:", owner.address);

  let waveCount;
  waveCount = await waveContract.getTotalWaves();
  
  //let waveTxn = await waveContract.wave();
  const waveTxn = await waveContract.wave();
  await waveTxn.wait();

  waveCount = await waveContract.getTotalWaves();
};

const runMain = async () => {
  try {
    await main();
    process.exit(0);
  } catch (error) {
    console.log(error);
    process.exit(1);
  }
};

runMain();
```