### PR TITLE
Add missing underscore for lessons 4 and 2 section 2

### DIFF
--- a/NFT_Collection/en/Section_1/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
+++ b/NFT_Collection/en/Section_1/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
@@ -295,7 +295,7 @@ module.exports = {
   solidity: '0.8.0',
   networks: {
     rinkeby: {
-      url: 'YOUR ALCHEMY_API_URL',
+      url: 'YOUR_ALCHEMY_API_URL',
       accounts: ['YOUR_PRIVATE_RINKEBY_ACCOUNT_KEY'],
     },
   },

--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
@@ -83,7 +83,7 @@ module.exports = {
   solidity: '0.8.0',
   networks: {
     rinkeby: {
-      url: 'YOUR ALCHEMY_API_URL',
+      url: 'YOUR_ALCHEMY_API_URL',
       accounts: ['YOUR_PRIVATE_RINKEBY_ACCOUNT_KEY'],
     },
   },


### PR DESCRIPTION
In order to have coherence with the naming convention of the `hardhat.config.js` file, I added the missing underscores for `YOUR ALCHEMY_API_URL` to `YOUR_ALCHEMY_API_URL`.