### PR TITLE
Fixed typo in Contracts course

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_3/Lesson_2_Fund_Contract_Set_Prize.md
+++ b/Solidity_And_Smart_Contracts/en/Section_3/Lesson_2_Fund_Contract_Set_Prize.md
@@ -164,7 +164,7 @@ We just sent some ETH from our contract, big success! And, we know we succeeded 
 ✈️ Update deploy script to fund contract
 ----------------------------------------
 
-We need to make a small update to `deploy.js`.
+We need to make a small update to `run.js`.
 
 ```javascript
 const main = async () => {


### PR DESCRIPTION
## Purpose

In the Build a Web3 App with Solidity + Ethereum Smart Contracts, Lesson 3 there is a typo. The code says to make the following changes to the `deploy.js` file. But is referring to the `run.js` file instead.

## Changes made

Corrected to refere to the correct file.