### PR TITLE
Simply S1 L1

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
@@ -31,8 +31,6 @@ Next, let's head to the terminal (Git Bash will not work). Go ahead and cd to th
 ```bash
 mkdir my-wave-portal
 cd my-wave-portal
-npm init -y
-npm install --save-dev hardhat
 ```
 
 👏 Get sample project going
@@ -53,7 +51,7 @@ The sample project will ask you to install hardhat-waffle and hardhat-ethers. Th
 Go ahead and install these other dependencies just in case it didn't do it automatically.
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-waffle ethereum-waffle chai @nomiclabs/hardhat-ethers ethers
+npm install --save-dev hardhat @nomiclabs/hardhat-waffle ethereum-waffle chai @nomiclabs/hardhat-ethers ethers
 ```
 
 Finally, run `npx hardhat accounts` and this should print out a bunch of strings that look like this: 


### PR DESCRIPTION
1) There is no need to initialize the npm project because `npx hardhat` do it for you
2) No need to install `hardhat` as dev dependency because `npx hardhat` do it for you
3) Add `hardhat` as dev dependency in case not installed automatically using `npx hardhat`