### PR TITLE
Change implementation and test to pass in the user's pubkey that call…

### DIFF
--- a/Solana_And_Web3/en/Section_2/Lesson_4_Store_Structs_On_Program.md
+++ b/Solana_And_Web3/en/Section_2/Lesson_4_Store_Structs_On_Program.md
@@ -21,15 +21,16 @@ pub mod myepicproject {
     base_account.total_gifs = 0;
     Ok(())
   }
-	 
-  // The fucntion now accepts a gif_link param from the user.
+
+  // The function now accepts a gif_link param from the user. We also reference the user from the Context
   pub fn add_gif(ctx: Context<AddGif>, gif_link: String) -> ProgramResult {
     let base_account = &mut ctx.accounts.base_account;
-		
+    let user = &mut ctx.accounts.user;
+
 	// Build the struct.
     let item = ItemStruct {
       gif_link: gif_link.to_string(),
-      user_address: *base_account.to_account_info().key,
+      user_address: *user.to_account_info().key,
     };
 		
 	// Add it to the gif_list vector.
@@ -48,10 +49,13 @@ pub struct StartStuffOff<'info> {
   pub system_program: Program <'info, System>,
 }
 
+// Add the signer who calls the AddGif method to the struct so that we can save it
 #[derive(Accounts)]
 pub struct AddGif<'info> {
   #[account(mut)]
   pub base_account: Account<'info, BaseAccount>,
+  #[account(mut)]
+  pub user: Signer<'info>,
 }
 
 // Create a custom struct for us to work with.
@@ -122,10 +126,11 @@ const main = async() => {
   let account = await program.account.baseAccount.fetch(baseAccount.publicKey);
   console.log('👀 GIF Count', account.totalGifs.toString())
 
-  // You'll need to now pass a GIF link to the function!
+  // You'll need to now pass a GIF link to the function! You'll also need to pass in the user submitting the GIF!
   await program.rpc.addGif("insert_a_giphy_link_here", {
     accounts: {
       baseAccount: baseAccount.publicKey,
+      user: provider.wallet.publicKey,
     },
   });
   

--- a/Solana_And_Web3/en/Section_3/Lesson_3_Submitting_GIF_To_Solana.md
+++ b/Solana_And_Web3/en/Section_3/Lesson_3_Submitting_GIF_To_Solana.md
@@ -14,6 +14,7 @@ const sendGif = async () => {
     await program.rpc.addGif(inputValue, {
       accounts: {
         baseAccount: baseAccount.publicKey,
+        user: provider.wallet.publicKey,
       },
     });
     console.log("GIF sucesfully sent to program", inputValue)


### PR DESCRIPTION
# Description

In the `add_gif` method, we set `user_address` on the newly created `ItemStruct` (which is meant to store a link to the GIF and the address of the user who submitted the GIF) to the public key of the `baseAddress`. My understanding is that this `baseAddress` is how Solana looks up the Account that stores state for the application. We want to change implementation and test to use the user's pubkey that called `add_gif` to the `AddGif` `Context` so that we can save that to the `ItemStruct.user_address`
## Changes

* Solana_And_Web3/en/Section_2/Lesson_4_Store_Structs_On_Program.md
  *   Update `pub fn add_gif`to reference the user from `ctx: Context<AddGif>` and change the value for `user_address` in `ItemStruct` to `*user.to_account_info().key` instead of `*base_account.to_account_info().key`
  * Update the test call `await program.rpc.addGif(...` by passing in `user: provider.wallet.publicKey,` in addition to `baseAddress`