### PR TITLE
Solana course: clean up side effects

### DIFF
--- a/Solana_And_Web3/en/Section_1/Lesson_2_Building_Connect_Wallet_Button.md
+++ b/Solana_And_Web3/en/Section_1/Lesson_2_Building_Connect_Wallet_Button.md
@@ -54,9 +54,11 @@ const App = () => {
    * Phantom Wallet
    */
   useEffect(() => {
-    window.addEventListener('load', async (event) => {
+    const onLoad = async () => {
       await checkIfWalletIsConnected();
-    });
+    };
+    window.addEventListener('load', onLoad);
+    return () => window.removeEventListener('load', onLoad);
   }, []);
 
   return (
@@ -111,9 +113,11 @@ Since we have tested this project fully with Phantom Wallets, we recommend stick
 
 ```jsx
 useEffect(() => {
-  window.addEventListener('load', async (event) => {
+  const onLoad = async () => {
     await checkIfWalletIsConnected();
-  });
+  };
+  window.addEventListener('load', onLoad);
+  return () => window.removeEventListener('load', onLoad);
 }, []);
 ```
 
@@ -236,9 +240,11 @@ const App = () => {
 
   // UseEffects
   useEffect(() => {
-    window.addEventListener('load', async (event) => {
+    const onLoad = async () => {
       await checkIfWalletIsConnected();
-    });
+    };
+    window.addEventListener('load', onLoad);
+    return () => window.removeEventListener('load', onLoad);
   }, []);
 
   return (
@@ -351,9 +357,11 @@ const App = () => {
 
   // UseEffects
   useEffect(() => {
-    window.addEventListener('load', async (event) => {
+    const onLoad = async () => {
       await checkIfWalletIsConnected();
-    });
+    };
+    window.addEventListener('load', onLoad);
+    return () => window.removeEventListener('load', onLoad);
   }, []);
 
   return (

--- a/Solana_And_Web3/en/Section_1/Lesson_3_Building_GIF_Grid.md
+++ b/Solana_And_Web3/en/Section_1/Lesson_3_Building_GIF_Grid.md
@@ -235,9 +235,11 @@ Right under your current `useEffect` **create another** `useEffect`.
 
 ```jsx
 useEffect(() => {
-  window.addEventListener('load', async (event) => {
+  const onLoad = async () => {
     await checkIfWalletIsConnected();
-  });
+  };
+  window.addEventListener('load', onLoad);
+  return () => window.removeEventListener('load', onLoad);
 }, []);
 
 useEffect(() => {


### PR DESCRIPTION
It's good hygiene to clean up after side effects when setting up event listeners. It's not critical in this example because `load` only fires ~once per page load and the `[]` effect dependencies also only triggers ~once, but a similar handler on another event without clean up would result in a memory leak.

Happy to add some notes to this to explain _why_ this is being done the way it is (and/or link out to the React docs). Just want to help set up folks for success in future projects by providing best practices ahead of time :) 

Also happy to simplify, e.g.

```jsx
useEffect(() => {
  window.addEventListener('load', checkIfWalletIsConnected);
  return () => window.removeEventListener('load', checkIfWalletIsConnected);
}, []);
```