### PR TITLE
Fixed a typo in the mintCharacterNFT function

### DIFF
--- a/NFT_Game/en/Section_1/Lesson_4_Mint_Your_NFT_Locally.md
+++ b/NFT_Game/en/Section_1/Lesson_4_Mint_Your_NFT_Locally.md
@@ -90,7 +90,7 @@ contract MyEpicGame is ERC721 {
       name: defaultCharacters[_characterIndex].name,
       imageURI: defaultCharacters[_characterIndex].imageURI,
       hp: defaultCharacters[_characterIndex].hp,
-      maxHp: defaultCharacters[_characterIndex].hp,
+      maxHp: defaultCharacters[_characterIndex].maxHp,
       attackDamage: defaultCharacters[_characterIndex].attackDamage
     });
 


### PR DESCRIPTION
In the function `mintCharacterNFT` , `maxHp` was assigned `defaultCharacters[_characterIndex].hp` instead of `defaultCharacters[_characterIndex].maxHp`