### PR TITLE
Add libssl-dev to Anchor dependencies

### DIFF
--- a/Solana_And_Web3/en/Section_2/Resources/windows_setup.md
+++ b/Solana_And_Web3/en/Section_2/Resources/windows_setup.md
@@ -178,7 +178,7 @@ This is going to help us later down the line :)
 From here run:
 
 ```bash
-sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev
+sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
 cargo install --git https://github.com/project-serum/anchor anchor-cli --locked
 ```
 


### PR DESCRIPTION
anchor-cli dependency openssl-sys requires a development package for openssl, for Ubuntu it's libssl-dev which doesn't seem to be installed with the rest of the deps.