### PR TITLE
Remove redundant curly braces in jsx

### DIFF
--- a/NFT_Collection/en/Section_3/Lesson_3_Create_Button_To_Call_Contract.md
+++ b/NFT_Collection/en/Section_3/Lesson_3_Create_Button_To_Call_Contract.md
@@ -70,10 +70,10 @@ Finally, we'll want to call this function when someone clicks the "Mint NFT" but
 
 ```javascript
 return (
-  {currentAccount === "" ? (
-    {renderNotConnectedContainer()}
-  ) : (
-    {/** Add askContractToMintNft Action for the onClick event **/}
+  {currentAccount === "" ? 
+    renderNotConnectedContainer()
+    : (
+    /** Add askContractToMintNft Action for the onClick event **/
     <button onClick={askContractToMintNft} className="cta-button connect-wallet-button">
       Mint NFT
     </button>


### PR DESCRIPTION
In the example for "Mint NFT" button, there were too many curly braces, which were causing the website to break. We only need the curly braces around the ternary operator. I removed the ones around the comment as well as the call to `renderNotConnectedContainer` function.