### PR TITLE
add fix for "toolchain '1.52.1-aarch64-apple-darwin' is not installed"

### DIFF
--- a/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
+++ b/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
@@ -99,9 +99,9 @@ For more information refer to [this PR with the original solution](https://githu
   
 If you receive an error that looks like this – `toolchain '1.52.1-aarch64-apple-darwin' is not installed` you can try to reinstall it:
 
-```
-  rustup toolchain uninstall stable
-  rustup toolchain install stable
+```bash
+rustup toolchain uninstall stable
+rustup toolchain install stable
 ```
 
 </details>

--- a/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
+++ b/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
@@ -94,6 +94,18 @@ openssl = { version = "0.10", features = ["vendored"] }
 For more information refer to [this PR with the original solution](https://github.com/solana-labs/solana/issues/20783).
 </details>
 
+<details>
+<summary>Having problems with <code>toolchain</code>?</summary>
+  
+If you receive an error that looks like this – `toolchain '1.52.1-aarch64-apple-darwin' is not installed` you can try to reinstall it:
+
+```
+  rustup toolchain uninstall stable
+  rustup toolchain install stable
+```
+
+</details>
+
 This might take some time, so don't be alarmed! Once you're done installing, run this to make sure everything is in working order:
 
 ```bash


### PR DESCRIPTION
I received this error when trying to run ```./scripts/cargo-install-all.sh .```.

Solution found here: https://github.com/rust-lang/rustup/issues/1793