### PR TITLE
fix: no need for _totalSupply parameter when verifying the contract.

### DIFF
--- a/NFT_Collection/en/Section_4/Lesson_2_Ship_It.md
+++ b/NFT_Collection/en/Section_4/Lesson_2_Ship_It.md
@@ -113,7 +113,7 @@ Sweet you got your API key. Time to head back to your `hardhat.config.js` file a
 We are down to our last step I promise. All that remains now is to run the command
 
 ```
-npx hardhat verify YOUR_CONTRACT_ADDRESS --network rinkeby _totalSupply
+npx hardhat verify YOUR_CONTRACT_ADDRESS --network rinkeby 
 ```
 
 If everything runs smoothly, you should see some outputs in the terminal. Mine looks like this:


### PR DESCRIPTION
# Problem 
when I was doing the contract verification I encountered an error with the command on the lecture. 
![Screen Shot 2021-11-23 at 10 06 38 PM](https://user-images.githubusercontent.com/11360957/143042848-41bf36a2-07ab-4662-8ec0-52481e309a3c.png)

after some research, I thought that maybe we don't need the argument '_totalSupply'?

#Refs 
https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html#usage