### PR TITLE
Add log message containing randomly generated #

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_4/Lesson_1_Randomly_Pick_Winner.md
+++ b/Solidity_And_Smart_Contracts/en/Section_4/Lesson_1_Randomly_Pick_Winner.md
@@ -60,6 +60,8 @@ contract WavePortal {
          * Generate a new seed for the next user that sends a wave
          */
         seed = (block.difficulty + block.timestamp + seed) % 100;
+        
+        console.log("Random # generated: %d", seed);
 
         /*
          * Give a 50% chance that the user wins the prize.


### PR DESCRIPTION
The [sample output](https://camo.githubusercontent.com/4d854f3a07a1d5c53d52e85bf4852b626b0e2397b6366bf2352d93e25281685a/68747470733a2f2f692e696d6775722e636f6d2f417258524373702e706e67) prints out the randomly generated number, but the code doesn't contain a line to do so.  This change adds the missing log message.