### PR TITLE
build solana v1.8.5 instead of v1.8.2

### DIFF
--- a/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
+++ b/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
@@ -53,11 +53,11 @@ We are to download with this command:
 git clone https://github.com/solana-labs/solana.git/
 ```
 
-Once it has finished cloning, we are going to enter the Solana directory and checkout the version branch `v1.8.2`:
+Once it has finished cloning, we are going to enter the Solana directory and checkout the version branch `v1.8.5`:
 
 ```bash
 cd solana
-git checkout v1.8.2
+git checkout v1.8.5
 ```
 
 `git checkout` is just switching to a stable version, so we can send ourselves some `$SOL` later on without receieving this error `Error: RPC response error -32601: Method not found`.


### PR DESCRIPTION
Reason:
v.1.8.2 leads to a bug where the function addGif in Section 2 / Lessono 3 won't work.
See https://github.com/project-serum/anchor/issues/1062


Update: In Section 2 / Lesson 4, M1 people will again get stuck. Didn't find a solution to this, and as I've had problems over and over again I've now moved my project to a Ubuntu VPS.
Should have done it sooner, now the tests just run through :)