### PR TITLE
Update m1_setup.md: install anchor/web3.js packages globally

### DIFF
--- a/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
+++ b/Solana_And_Web3/en/Section_2/Resources/m1_setup.md
@@ -201,7 +201,7 @@ If you got that working, nice, you have Anchor!!
 We'll also use Anchor's npm module and Solana Web3 JS — these both will help us connect our web app to our Solana program!
 
 ```bash
-npm install @project-serum/anchor @solana/web3.js
+npm install -g @project-serum/anchor @solana/web3.js
 ```
 
 ### 🏃‍♂️ Create a test project and run it.


### PR DESCRIPTION
Earlier on in this guide we install the mocha npm package globally 
```
$ npm install -g mocha
```

It seems appropriate to me in this context that we would also install the anchor & solana/web3.js npm packages globally

```
$ npm install -g @project-serum/anchor @solana/web3.js
```

---------------
Potentially related - the first time I ran through this guide I ran into some difficult to debug opaque issues running the `anchor test...` step that cleared up when I uninstalled and restarted the process using a global npm install

Not sure if these things were related but in hindsight it could have potentially been because I local-installed the anchor npm package in a different directory to where I was trying to use it (ie. in the `myepicproject` directory)

Hope this helps - love what you guys are building! 😄 