### PR TITLE
typo in metaplex clone step, had markdown link

### DIFF
--- a/Solana_NFTs/en/Section_2/Lesson_1_Get_Solana_Running.md
+++ b/Solana_NFTs/en/Section_2/Lesson_1_Get_Solana_Running.md
@@ -97,7 +97,7 @@ Now that we have our Solana CLI installed, we'll need to install the Metaplex CL
 Let's start by cloning a repo from Github. *I recommend cloning the repo to the home folder of your repo. So, you can do a `cd ~`  to get there (not sure what it is on Windows lol).*
 
 ```plaintext
-git clone --branch v1.0.0 [https://github.com/metaplex-foundation/metaplex.git](https://github.com/metaplex-foundation/metaplex.git) ~/metaplex-foundation/metaplex
+git clone --branch v1.0.0 https://github.com/metaplex-foundation/metaplex.git ~/metaplex-foundation/metaplex
 ```
 
 From here it's just a matter of installing all the dependencies for this CLI, by using this command in the directory where you just installed Metaplex. Note: I don't actually cd into the folder. I just run all the commands I need from outside the folder. I never actually go inside the `metaplex-foundation` folder. You'll see why this is easier later!


### PR DESCRIPTION
The plaintext code block for cloning metaplex repo had a markdown link causing an error if you copy and paste into your terminal.