### PR TITLE
rename walletAddress prop to wallet

### DIFF
--- a/Solana_NFTs/en/Section_3/Lesson_1_Call_Candy_Machine_From_App.md
+++ b/Solana_NFTs/en/Section_3/Lesson_1_Call_Candy_Machine_From_App.md
@@ -84,7 +84,7 @@ import React, { useEffect } from 'react';
 
 ...
 
-const CandyMachine = ({ walletAddress }) => {
+const CandyMachine = ({ wallet }) => {
 
   ...
   
@@ -215,8 +215,8 @@ return (
           <p className="sub-text">NFT drop machine with fair mint</p>
           {!walletAddress && renderNotConnectedContainer()}
         </div>
-        {/* Check for walletAddress and then pass in walletAddress */}
-      {walletAddress && <CandyMachine walletAddress={window.solana} />}
+        {/* Check for wallet and then pass in window.solana */}
+      {walletAddress && <CandyMachine wallet={window.solana} />}
         <div className="footer-container">
           <img alt="Twitter Logo" className="twitter-logo" src={twitterLogo} />
           <a
@@ -265,7 +265,7 @@ import React, { useEffect, useState } from 'react';
 
 ...
 
-const CandyMachine({walletAddress}) => {
+const CandyMachine({ wallet }) => {
   // Add state property inside your component like this
   const [machineStats, setMachineStats] = useState(null);
 

--- a/Solana_NFTs/en/Section_3/Lesson_1_Call_Candy_Machine_From_App.md
+++ b/Solana_NFTs/en/Section_3/Lesson_1_Call_Candy_Machine_From_App.md
@@ -215,7 +215,7 @@ return (
           <p className="sub-text">NFT drop machine with fair mint</p>
           {!walletAddress && renderNotConnectedContainer()}
         </div>
-        {/* Check for wallet and then pass in window.solana */}
+        {/* Check for walletAddress and then pass in window.solana */}
       {walletAddress && <CandyMachine wallet={window.solana} />}
         <div className="footer-container">
           <img alt="Twitter Logo" className="twitter-logo" src={twitterLogo} />

--- a/Solana_NFTs/en/Section_3/Lesson_2_Create_Mint_NFT_Button.md
+++ b/Solana_NFTs/en/Section_3/Lesson_2_Create_Mint_NFT_Button.md
@@ -15,7 +15,7 @@ But lets look at some chunks of code:
 ```jsx
 const mint = web3.Keypair.generate();
 const token = await getTokenWallet(
-  walletAddress.publicKey,
+  wallet.publicKey,
   mint.publicKey
 );
 const metadata = await getMetadata(mint.publicKey);
@@ -33,13 +33,13 @@ Here we're creating an account for our NFT. In Solana, programs are **stateless*
 const accounts = {
   config,
   candyMachine: process.env.REACT_APP_CANDY_MACHINE_ID,
-  payer: walletAddress.publicKey,
+  payer: wallet.publicKey,
   wallet: process.env.REACT_APP_TREASURY_ADDRESS,
   mint: mint.publicKey,
   metadata,
   masterEdition,
-  mintAuthority: walletAddress.publicKey,
-  updateAuthority: walletAddress.publicKey,
+  mintAuthority: wallet.publicKey,
+  updateAuthority: wallet.publicKey,
   tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
   tokenProgram: TOKEN_PROGRAM_ID,
   systemProgram: SystemProgram.programId,
@@ -55,7 +55,7 @@ Here's are all the params candy machine needs to mint the NFT. It needs everythi
 ```jsx
 const instructions = [
   web3.SystemProgram.createAccount({
-    fromPubkey: walletAddress.publicKey,
+    fromPubkey: wallet.publicKey,
     newAccountPubkey: mint.publicKey,
     space: MintLayout.span,
     lamports: rent,
@@ -65,20 +65,20 @@ const instructions = [
     TOKEN_PROGRAM_ID,
     mint.publicKey,
     0,
-    walletAddress.publicKey,
-    walletAddress.publicKey
+    wallet.publicKey,
+    wallet.publicKey
   ),
   createAssociatedTokenAccountInstruction(
     token,
-    walletAddress.publicKey,
-    walletAddress.publicKey,
+    wallet.publicKey,
+    wallet.publicKey,
     mint.publicKey
   ),
   Token.createMintToInstruction(
     TOKEN_PROGRAM_ID,
     mint.publicKey,
     token,
-    walletAddress.publicKey,
+    wallet.publicKey,
     [],
     1
   ),


### PR DESCRIPTION
having this prop named walletAddress makes it seems like it should accept the `walletAddres` state variable in `App.js` when it's meant to take `window.solana`. I think naming it `wallet` would be a bit clearer as it's a wallet object.

paralel PR for the base project repo [here](https://github.com/buildspace/nft-drop-starter-project/pull/15)