### PR TITLE
Add hint to add LoadingIndicator to Arena/index.js

### DIFF
--- a/NFT_Game/en/Section_4/Lesson_1_Finishing_Touches_UI.md
+++ b/NFT_Game/en/Section_4/Lesson_1_Finishing_Touches_UI.md
@@ -294,7 +294,13 @@ For this all we will need to do is add some conditional rendering in our HTML. G
 </div>;
 ```
 
-Make sure to also add this CSS to your `Arena.css` file:
+Make sure to import `LoadingIndicator` at the top of your `index.js` file:
+
+```javascript
+import LoadingIndicator from '../../Components/LoadingIndicator';
+```
+
+Also make sure to also add this CSS to your `Arena.css` file:
 
 ```css
 .boss-container .loading-indicator {


### PR DESCRIPTION
Without adding LoadingIndicator, the user gets a Reference Error and a blank page is shown.