### PR TITLE
Add info on manually install ethers package

### DIFF
--- a/NFT_Collection/en/Section_3/Lesson_3_Create_Button_To_Call_Contract.md
+++ b/NFT_Collection/en/Section_3/Lesson_3_Create_Button_To_Call_Contract.md
@@ -42,6 +42,10 @@ const signer = provider.getSigner();
 ```
 
 `ethers` is a library that helps our frontend talk to our contract. Be sure to import it at the top using `import { ethers } from "ethers";`.
+If you run into an error like:
+`Failed to resolve import "ethers" from "src/App.jsx". Does the file exist?`
+Check that the `ethers` library is added in the projects dependency list. If it's missing it can be added manually in Replit from the "packages" tab in the menu to the left
+
 
 A "Provider" is what we use to actually talk to Ethereum nodes. Remember how we were using Alchemy to **deploy**? Well in this case we use nodes that Metamask provides in the background to send/receive data from our deployed contract.
 


### PR DESCRIPTION
Ethers is not in the dependencies. Added instructions on how to add it from the packages tab in Replit.