### PR TITLE
Update Lesson_3_Depoy_NFTs_To_Devnet.md

### DIFF
--- a/Solana_NFTs/en/Section_2/Lesson_3_Depoy_NFTs_To_Devnet.md
+++ b/Solana_NFTs/en/Section_2/Lesson_3_Depoy_NFTs_To_Devnet.md
@@ -43,10 +43,10 @@ solana balance
 And it should say `0 SOL`. We can't deploy stuff to Solana without SOL, writing data to the blockchain costs money. In this case, we're on dev net so we can just give ourselves fake SOL. Go ahead and run:
 
 ```plaintext
-solana airdrop 5
+solana airdrop 2
 ```
 
-After that's done, you can run `solana balance` again and bam you'll have some SOL. *Note: if you ever run out of fake SOL, you can just run this command again.*
+After that's done, you can run `solana balance` again and bam you'll have some SOL. *Note: only a maximum of 2 SOL can be airdropped on the devnet, and if you ever run out of fake SOL, you can just run this command again.*
 
 ### 🚀 **Upload the NFTs**
 


### PR DESCRIPTION
Updated the `solana airdrop 5` CLI command and note.

Solana Devnet only allows for a maximum of 2 SOL to be airdropped. Changing it from 5 to 2 provides greater clarity and reduces confusion for students. 