### PR TITLE
Update Lesson_5_Deploy_Locally.md correcting typo

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_5_Deploy_Locally.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_5_Deploy_Locally.md
@@ -51,7 +51,7 @@ const runMain = async () => {
     await main();
     process.exit(0);
   } catch (error) {
-    console.error(error);
+    console.log(error);
     process.exit(1);
   }
 };


### PR DESCRIPTION
LINE 54: In the runMain const, when there is an error, it should read "console.log(error)". It currently reads "console.error(error)"