### PR TITLE
Fix comment typo: instatiate -> instantiate

### DIFF
--- a/JS_DAO/en/Section_2/Lesson_3_Let_Users_Mint_Your_NFT.md
+++ b/JS_DAO/en/Section_2/Lesson_3_Let_Users_Mint_Your_NFT.md
@@ -17,7 +17,7 @@ import { ThirdwebSDK } from "@3rdweb/sdk";
 From there, here's what we're going to add:
 
 ```jsx
-// We instatiate the sdk on Rinkeby.
+// We instantiate the sdk on Rinkeby.
 const sdk = new ThirdwebSDK("rinkeby");
 
 // We can grab a reference to our ERC-1155 contract.


### PR DESCRIPTION
Fix comment typo: `instatiate` -> `instantiate`