### PR TITLE
Fixes expected output to mirror code output

### DIFF
--- a/JS_DAO/en/Section_2/Lesson_2_Deploy_NFT_Metadata.md
+++ b/JS_DAO/en/Section_2/Lesson_2_Deploy_NFT_Metadata.md
@@ -105,7 +105,7 @@ After running `node scripts/4-set-claim-condition.js` here's what I get:
 
 ```
 👋 Your app address is: 0xa002D595189bF9D50D5897C64b6e07BE5bdEe9b8
-✅ Sucessfully set claim condition on bundle drop: 0x31c70F45060AE0870624Dd9D79A1d8dafC095A
+✅ Sucessfully set claim condition!
 ```
 
 Boom! We've successfully interacted w/ our deployed smart contract and have given our NFT certain rules it must follow, hell yea! If you copy-paste your bundle drop address printed out there and search it on `https://rinkeby.etherscan.io/`, you'll see proof right there that we interact w/ the contract!


### PR DESCRIPTION
Relevant line in `scripts/4-set-claim-conditions.js` is:
```
console.log("✅ Successfully set claim conditions!");
```

Paragraph later "After running node scripts/4-set-claim-condition.js
here's what I get:" shows different output than what you'd get if you
run sample code.