### PR TITLE
Add chainlink faucet to Section_2 - Lesson_2 of Solidity_and_smart_contracts 

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
@@ -67,6 +67,7 @@ For MyCrypto, you'll need to connect your wallet, make an account, and then clic
 | Official Rinkeby | https://faucet.rinkeby.io/            | 3 / 7.5 / 18.75 | 8h / 1d / 3d |
 | Chainlink        | https://faucets.chain.link/rinkeby    | 0.1             | None         |
 
+
 🙃 Having trouble getting Testnet ETH?
 -----------------------------------
 

--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
@@ -65,7 +65,7 @@ For MyCrypto, you'll need to connect your wallet, make an account, and then clic
 | Buildspace       | https://buildspace-faucet.vercel.app/ | 0.025           | 1d           |
 | Ethily           | https://ethily.io/rinkeby-faucet/     | 0.2             | 1w           |
 | Official Rinkeby | https://faucet.rinkeby.io/            | 3 / 7.5 / 18.75 | 8h / 1d / 3d |
-
+| Chainlink        | https://faucets.chain.link/rinkeby    | 0.1             | None         |
 
 🙃 Having trouble getting Testnet ETH?
 -----------------------------------


### PR DESCRIPTION
Since all the faucets listed on the current live version of the doc didn't work for me (no ETH to send or failing Tx) I google for alternatives and this one from Chainlink works quite well.