### PR TITLE
Add M1 Node Version Note If Installing Node

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
@@ -26,6 +26,8 @@ If you have any issues throughout here, just drop a message on Discord in  `#se
 
 First you'll need to get node/npm. If you don't have it head over [here](https://hardhat.org/tutorial/setting-up-the-environment.html).
 
+*Note: if you are installing node on an M1 macOS machine you will need to install node version 15 or greater*
+
 Next, let's head to the terminal (Git Bash will not work). Go ahead and cd to the directory you want to work in. Once you're there run these commands:
 
 ```bash

--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
@@ -26,7 +26,7 @@ If you have any issues throughout here, just drop a message on Discord in  `#se
 
 First you'll need to get node/npm. If you don't have it head over [here](https://hardhat.org/tutorial/setting-up-the-environment.html).
 
-*Note: if you are installing node on an M1 macOS machine you will need to install node version 15 or greater*
+We recommend you install at least node v15 or you may run into some issues!
 
 Next, let's head to the terminal (Git Bash will not work). Go ahead and cd to the directory you want to work in. Once you're there run these commands:
 


### PR DESCRIPTION
Added note to the node install section that M1 macOS machines will need to install a node version greater than the node version shown in the hardhat docs(node v12) to run hardhat commands properly. I installed node version 16 and hardhat commands worked for me but I believe any version greater than 15 should resolve the issue based on [this](https://stackoverflow.com/a/66380037) conversation.  

Error log when running hardhat command `npx hardhat accounts` on node v12:

```
<--- Last few GCs --->

[24225:0x158008000]      411 ms: Scavenge 24.2 (34.4) -> 20.0 (52.6) MB, 0.9 / 0.0 ms  (average mu = 1.000, current mu = 1.000) allocation failure


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x00010d5c08d1 <JSObject>
    0: builtin exit frame: compileFunction(this=0x00010d8028c9 <JSGlobal Object>,0x00010ff4e449 <JSArray[5]>,0x00010ff4e419 <JSArray[0]>,0x0001052804b1 <undefined>,0x0001052806e9 <false>,0x0001052804b1 <undefined>,0,0,0x00010ff4c3c1 <String[97]: /Users/user/dev/buildspace/ethereum_course/my-wave-portal/node_modules/rustbn.js/lib/index.asm.js>,0x000110980119 <Very long string[633703]>,0x00010d802...

FATAL ERROR: wasm code commit Allocation failed - process out of memory
 1: 0x10283b3d8 node::Abort() [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 2: 0x10283b53c node::OnFatalError(char const*, char const*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 3: 0x10295b2d0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 4: 0x10295b264 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 5: 0x102e9a744 v8::internal::wasm::WasmCodeAllocator::AllocateForCodeInRegion(v8::internal::wasm::NativeModule*, unsigned long, v8::base::AddressRegion) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 6: 0x102e9b570 v8::internal::wasm::NativeModule::CreateEmptyJumpTableInRegion(unsigned int, v8::base::AddressRegion) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 7: 0x102e9aa38 v8::internal::wasm::NativeModule::AddCodeSpace(v8::base::AddressRegion) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 8: 0x102e9b3ac v8::internal::wasm::NativeModule::NativeModule(v8::internal::wasm::WasmEngine*, v8::internal::wasm::WasmFeatures const&, bool, v8::internal::VirtualMemory, std::__1::shared_ptr<v8::internal::wasm::WasmModule const>, std::__1::shared_ptr<v8::internal::Counters>, std::__1::shared_ptr<v8::internal::wasm::NativeModule>*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
 9: 0x102e9d61c v8::internal::wasm::WasmCodeManager::NewNativeModule(v8::internal::wasm::WasmEngine*, v8::internal::Isolate*, v8::internal::wasm::WasmFeatures const&, unsigned long, bool, std::__1::shared_ptr<v8::internal::wasm::WasmModule const>) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
10: 0x102ea3cec v8::internal::wasm::WasmEngine::NewNativeModule(v8::internal::Isolate*, v8::internal::wasm::WasmFeatures const&, unsigned long, bool, std::__1::shared_ptr<v8::internal::wasm::WasmModule const>) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
11: 0x102ea3c2c v8::internal::wasm::WasmEngine::NewNativeModule(v8::internal::Isolate*, v8::internal::wasm::WasmFeatures const&, std::__1::shared_ptr<v8::internal::wasm::WasmModule const>) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
12: 0x102e7b5d8 v8::internal::wasm::CompileToNativeModule(v8::internal::Isolate*, v8::internal::wasm::WasmFeatures const&, v8::internal::wasm::ErrorThrower*, std::__1::shared_ptr<v8::internal::wasm::WasmModule const>, v8::internal::wasm::ModuleWireBytes const&, v8::internal::Handle<v8::internal::FixedArray>*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
13: 0x102ea14d0 v8::internal::wasm::WasmEngine::SyncCompileTranslatedAsmJs(v8::internal::Isolate*, v8::internal::wasm::ErrorThrower*, v8::internal::wasm::ModuleWireBytes const&, v8::internal::Vector<unsigned char const>, v8::internal::Handle<v8::internal::HeapNumber>, v8::internal::LanguageMode) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
14: 0x102992324 v8::internal::AsmJsCompilationJob::FinalizeJobImpl(v8::internal::Handle<v8::internal::SharedFunctionInfo>, v8::internal::Isolate*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
15: 0x102a1580c v8::internal::(anonymous namespace)::FinalizeUnoptimizedCompilationJob(v8::internal::UnoptimizedCompilationJob*, v8::internal::Handle<v8::internal::SharedFunctionInfo>, v8::internal::Isolate*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
16: 0x102a11f98 v8::internal::(anonymous namespace)::CompileToplevel(v8::internal::ParseInfo*, v8::internal::Isolate*, v8::internal::IsCompiledScope*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
17: 0x102a1414c v8::internal::Compiler::GetWrappedFunction(v8::internal::Handle<v8::internal::String>, v8::internal::Handle<v8::internal::FixedArray>, v8::internal::Handle<v8::internal::Context>, v8::internal::Compiler::ScriptDetails const&, v8::ScriptOriginOptions, v8::internal::ScriptData*, v8::ScriptCompiler::CompileOptions, v8::ScriptCompiler::NoCacheReason) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
18: 0x102965e9c v8::ScriptCompiler::CompileFunctionInContext(v8::Local<v8::Context>, v8::ScriptCompiler::Source*, unsigned long, v8::Local<v8::String>*, unsigned long, v8::Local<v8::Object>*, v8::ScriptCompiler::CompileOptions, v8::ScriptCompiler::NoCacheReason, v8::Local<v8::ScriptOrModule>*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
19: 0x102830688 node::contextify::ContextifyContext::CompileFunction(v8::FunctionCallbackInfo<v8::Value> const&) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
20: 0x1029c0300 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
21: 0x1029bf8f8 v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
22: 0x1029bf180 v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
23: 0x103095dec Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
24: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
25: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
26: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
27: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
28: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
29: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
30: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
31: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
32: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
33: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
34: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
35: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
36: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
37: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
38: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
39: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
40: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
41: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
42: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
43: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
44: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
45: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
46: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
47: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
48: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
49: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
50: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
51: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
52: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
53: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
54: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
55: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
56: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
57: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
58: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
59: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
60: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
61: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
62: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
63: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
64: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
65: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
66: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
67: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
68: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
69: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
70: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
71: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
72: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
73: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
74: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
75: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
76: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
77: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
78: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
79: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
80: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
81: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
82: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
83: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
84: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
85: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
86: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
87: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
88: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
89: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
90: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
91: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
92: 0x1030cb840 Builtins_ProxyGetProperty [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
93: 0x1030f3348 Builtins_LdaNamedPropertyHandler [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
94: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
95: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
96: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
97: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
98: 0x1030cb840 Builtins_ProxyGetProperty [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
99: 0x1030f3348 Builtins_LdaNamedPropertyHandler [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
100: 0x103018240 Builtins_InterpreterEntryTrapoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
101: 0x103010708 Builtins_ArgumentsAdaptorTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
102: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
103: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
104: 0x103018240 Builtins_InterpreterEntryTrampoline [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
105: 0x103044be4 Builtins_AsyncFunctionAwaitResolveClosure [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
106: 0x103069320 Builtins_PromiseFulfillReactionJob [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
107: 0x103036be0 Builtins_RunMicrotasks [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
108: 0x1030151ac Builtins_JSRunMicrotasksEntry [/Users/user/.nvm/versions/node/v12.22.8/bin/node]
109: 0x158008000
zsh: abort      npx hardhat accounts
```