### PR TITLE
Fix mintNft promise callbacks

### DIFF
--- a/JS_DAO/en/Section_2/Lesson_3_Let_Users_Mint_Your_NFT.md
+++ b/JS_DAO/en/Section_2/Lesson_3_Let_Users_Mint_Your_NFT.md
@@ -142,19 +142,20 @@ const App = () => {
     // Call bundleDropModule.claim("0", 1) to mint nft to user's wallet.
     bundleDropModule
     .claim("0", 1)
-    .catch((err) => {
-      console.error("failed to claim", err);
-      setIsClaiming(false);
-    })
-    .finally(() => {
-      // Stop loading state.
-      setIsClaiming(false);
+    .then((res) => {
       // Set claim state.
       setHasClaimedNFT(true);
       // Show user their fancy new NFT!
       console.log(
         `🌊 Successfully Minted! Check it out on OpenSea: https://testnets.opensea.io/assets/${bundleDropModule.address}/0`
       );
+    })
+    .catch((err) => {
+      console.error("failed to claim", err);
+    })
+    .finally(() => {
+      // Stop loading state.
+      setIsClaiming(false);
     });
   }
 


### PR DESCRIPTION
Moved setHasClaimedNFT(true) and OpenSea link log from 'finally' to 'then' callback, to show it ONLY if NFT was minted. Currently, even if transaction failed or user rejected the tx, the log was showed and user was taken to DAO Home Page.