### PR TITLE
Update airdrop to be 2 SOL instead of 5

### DIFF
--- a/Solana_And_Web3/en/Section_3/Lesson_2_Call_Deployed_Program.md
+++ b/Solana_And_Web3/en/Section_3/Lesson_2_Call_Deployed_Program.md
@@ -86,7 +86,7 @@ You'll need the public address associated w/ your Phantom wallet which you can g
 Now, go ahead and run this from your terminal.
 
 ```bash
-solana airdrop 5 INSERT_YOUR_PHANTOM_PUBLIC_ADDRESS_HERE  --url devnet
+solana airdrop 2 INSERT_YOUR_PHANTOM_PUBLIC_ADDRESS_HERE  --url devnet
 ```
 
 Now, when you go back to your Phantom wallet you should have 5 SOL associated w/ your devnet wallet. Nice :).


### PR DESCRIPTION
Trying to airdrop 5 SOL results in an error since there is a cap now and you can only do 2. This PR just updates the guide