### PR TITLE
changes made in S2L2 Transactions

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
@@ -12,7 +12,7 @@ Sorry for having you make so many accounts, but, this ecosystem is complex and w
 💳 Transactions
 ---------------
 
-So, when we want to perform an action on the Ethereum blockchain we call it a *transaction*. For example, sending someone Ethereum is a transaction. Doing something that updates a variable in our contract is also considered a transaction.
+So, when we want to perform an action on the Ethereum blockchain we call it a *transaction*. For example, sending someone Ether (ETH) is a transaction. Doing something that updates a variable in our contract is also considered a transaction.
 
 So when we call `wave` and it does `totalWaves += 1`, that's a transaction! **Deploying a smart contract is also a transaction.**
 


### PR DESCRIPTION
Hi devs! I am issuing a request to change the following line in the Section 2 Lesson 2 (Setting up to deploy a blockchain) of Intro to Web3 under the Transactions sub-heading:
"For example, sending someone Ethereum is a transaction".

It must be changed to:
"For example, sending Ether (ETH) is a transaction".

This is to prevent new comers from being confused between Ethereum and Ether.

Thanks!!