### PR TITLE
Airdrop 2 & MacOS CMv1CLI delete note

### DIFF
--- a/Solana_NFTs/en/Section_2/Lesson_1_Get_Solana_Running.md
+++ b/Solana_NFTs/en/Section_2/Lesson_1_Get_Solana_Running.md
@@ -115,6 +115,8 @@ ts-node ~/metaplex-foundation/metaplex/js/packages/cli/src/candy-machine-v2-cli.
 
 This should spit out `0.0.2`. At this point, we are good to go to start setting up our NFTs :).
 
+**Note**: If you're on MacOS, you might run into an issue if you had the old version of the Metaplex CLI installed. Make sure you delete the `metaplex-foundation` or `metaplex` directory in your `~` folder!
+ 
 ### 🚨 Progress Report
 
 *Please do this else Farza will be sad :(*

--- a/Solana_NFTs/en/Section_3/Lesson_2_Create_Mint_NFT_Button.md
+++ b/Solana_NFTs/en/Section_3/Lesson_2_Create_Mint_NFT_Button.md
@@ -165,7 +165,7 @@ First grab you Phantom wallet's public address:
 Then, on your terminal run:
 
 ```plaintext
-solana airdrop 5 INSERT_YOUR_PHANTOM_WALLET_ADDRESS
+solana airdrop 2 INSERT_YOUR_PHANTOM_WALLET_ADDRESS
 ```
 
 And that's it. Congrats on all the free money heh.


### PR DESCRIPTION
Changed 

```
solana airdrop 5
```
to 
```
solana airdrop 2
```
wherever relevant 

and added this note in the Get_Solana_Running section:
```
**Note**: If you're on MacOS, you might run into an issue if you had the old version of the Metaplex CLI installed. Make sure you delete the `metaplex-foundation` or `metaplex` directory in your `~` folder!
```