### PR TITLE
Update Lesson_2_Call_Deployed_Program.md

### DIFF
--- a/Solana_And_Web3/en/Section_3/Lesson_2_Call_Deployed_Program.md
+++ b/Solana_And_Web3/en/Section_3/Lesson_2_Call_Deployed_Program.md
@@ -318,7 +318,7 @@ const renderConnectedContainer = () => {
 }
 ```
 
-Pretty straightforward! I made some changes in `[gifList.map](http://gifList.map)`. Watch out for those!
+Pretty straightforward! I made some changes in `gifList.map`. Watch out for those!
 
 ### 🥳 Let's test!
 


### PR DESCRIPTION
Change typo from `[gifList.map](http://gifList.map)` to `gifList.map`. The former incorrectly uses syntax for hyperlinks.