### PR TITLE
Fix typo (Markdown) in Section_4_Lesson_2_Finalize_Celebrate.md

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_4/Lesson_2_Finalize_Celebrate.md
+++ b/Solidity_And_Smart_Contracts/en/Section_4/Lesson_2_Finalize_Celebrate.md
@@ -34,7 +34,7 @@ wavePortalContract.wave(message, { gasLimit: 300000 })
 
 What this does is make the user pay a set amount of gas of 300,000. And, if they don't use all of it in the transaction they'll automatically be refunded.
 
-So, if a transaction costs 250,000 gas then *after *that transaction is finalized that 50,000 gas left over that the user didn't use will be refunded :).
+So, if a transaction costs 250,000 gas then *after* that transaction is finalized that 50,000 gas left over that the user didn't use will be refunded :).
 
 🔍 Validating the transaction
 ---------------------------


### PR DESCRIPTION
The position of a blank space renders incorrectly _after_ word, which should be italic. Also, there's a missing space after "*" char