### PR TITLE
[NFT-Game] Corrected alert link to view NFT on OpenSea

### DIFF
--- a/NFT_Game/en/Section_3/Lesson_5_Building_Character_Select_Page.md
+++ b/NFT_Game/en/Section_3/Lesson_5_Building_Character_Select_Page.md
@@ -321,7 +321,7 @@ You freaking did it! Now that we have our character NFT we can finally go out an
 Feel free to also set up an `alert` that automatically gives your player the OpenSea link when it's done minting. For example something like:
 
 ```javascript
-alert(`Your NFT is all done -- see it here: https://testnets.opensea.io/assets/${gameContract}/${tokenId.toNumber()}`)
+alert(`Your NFT is all done -- see it here: https://testnets.opensea.io/assets/${CONTRACT_ADDRESS}/${tokenId.toNumber()}`)
 ```
 
 ### **🚨 Progress report.**


### PR DESCRIPTION
The alert to view your minted NFT on OpenSea does not provide a proper link as it renders the contract object instead of the contract address in text.

**Before**

![ss20](https://user-images.githubusercontent.com/50524862/154245755-7d6cfc79-6d8c-496e-8c06-014094ddf1b2.png)

**After**

![ss21](https://user-images.githubusercontent.com/50524862/154245796-c4aedc55-cd89-49b9-971b-e3a1db6f4ffd.png)


