### PR TITLE
Updated line 125- it was calling render.. 3 times

### DIFF
--- a/Polygon_ENS/en/Section_2/Lesson_3_Mint_A_Domain.md
+++ b/Polygon_ENS/en/Section_2/Lesson_3_Mint_A_Domain.md
@@ -122,7 +122,7 @@ const App = () => {
 					</header>
 				</div>
 				
-				{!currentAccount && renderNotConnectedContainer()}{!currentAccount && renderNotConnectedContainer()}{!currentAccount && renderNotConnectedContainer()}
+				{!currentAccount && renderNotConnectedContainer()}
 				{/* Render the input form if an account is connected */}
 				{currentAccount && renderInputForm()}
 				


### PR DESCRIPTION
{!currentAccount && renderNotConnectedContainer()}{!currentAccount && renderNotConnectedContainer()}{!currentAccount && renderNotConnectedContainer()}
This was the original code, when metamask isnt connected to the site, this line would display the gif and the connect wallet button much more than one time.