### PR TITLE
Simplify json in Polygon_ENS/en/Section_1/Lesson_4_Sell_Domains_As_NFTs.md

### DIFF
--- a/Polygon_ENS/en/Section_1/Lesson_4_Sell_Domains_As_NFTs.md
+++ b/Polygon_ENS/en/Section_1/Lesson_4_Sell_Domains_As_NFTs.md
@@ -404,9 +404,7 @@ function register(string calldata name) public payable {
   console.log("Registering %s on the contract with tokenID %d", name, newRecordId);
 
   string memory json = Base64.encode(
-    bytes(
-      string(
-        abi.encodePacked(
+      abi.encodePacked(
           '{"name": "',
           _name,
           '", "description": "A domain on the Ninja name service", "image": "data:image/svg+xml;base64,',
@@ -414,9 +412,7 @@ function register(string calldata name) public payable {
           '","length":"',
           strLen,
           '"}'
-        )
       )
-    )
   );
 
   string memory finalTokenUri = string( abi.encodePacked("data:application/json;base64,", json));


### PR DESCRIPTION
abi.encodePacked return in bytes. The code convert to string then to convert back to bytes making the code looks more complicated. 
bytes and string convertions are removed. the json's value remain the same.