### PR TITLE
Use a more common grammar in Solidity_And_Smart_Contracts/en/Section_1/Lesson_4

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_4_Store_Data_On_Smart_Contract.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_4_Store_Data_On_Smart_Contract.md
@@ -95,7 +95,7 @@ runMain();
 ```
 **VSCode might auto-import `ethers`. We don't need to import `ethers`. So, make sure you have no imports. Remember, what we talked about last lesson about hre?**
 
-🤔 How's it work?
+🤔 How does it work?
 -----------------
 
 ```javascript


### PR DESCRIPTION
This PR will replace the use of "apostrophe  + s" that was representing "does", with "does" itself, to make the title more understandable.  

Note: I'm not a native English speaker myself, and I had never seen such a use of "apostrophe + s" before. It was a little bit like "wait, what?" to me first. I searched a little bit and realized that it's not incorrect, but maybe it's just not so commonly used and is unfamiliar to some people.  
However, I might be wrong and this might be very commonly used. Feel free to close this tiny PR, if it's the case.
