### PR TITLE
Updated Polygon_ENS-Section_2-Lesson_3

### DIFF
--- a/Polygon_ENS/en/Section_2/Lesson_3_Mint_A_Domain.md
+++ b/Polygon_ENS/en/Section_2/Lesson_3_Mint_A_Domain.md
@@ -221,7 +221,7 @@ const mintDomain = async () => {
 				console.log("Domain minted! https://mumbai.polygonscan.com/tx/"+tx.hash);
 				
 				// Set the record for the domain
-				tx = contract.setRecord(domain, record);
+				tx = await contract.setRecord(domain, record);
 				await tx.wait();
 
 				console.log("Record set! https://mumbai.polygonscan.com/tx/"+tx.hash);


### PR DESCRIPTION
Fix #983 
Added await in line-224 in Polygon_ENS / Section_2 / Lesson_3_Mint_A_Domain.

`tx = contract.setRecord(domain, record);` to `tx = await contract.setRecord(domain, record);`

![mint](https://user-images.githubusercontent.com/56548922/155854285-16a6ddaa-6965-442d-90ec-8998c2637b32.png)

