### PR TITLE
Added npm install --save dotenv

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
@@ -91,7 +91,47 @@ module.exports = {
 };
 ```
 
-**Note: DON'T COMMIT THIS FILE TO GITHUB. IT HAS YOUR PRIVATE KEY. YOU WILL GET HACKED + ROBBED. THIS PRIVATE KEY IS THE SAME AS YOUR MAINNET PRIVATE KEY.** We'll talk about `.env` variables later and how to keep this stuff secret.
+**Note: DON'T COMMIT THIS FILE TO GITHUB. IT HAS YOUR PRIVATE KEY. YOU WILL GET HACKED + ROBBED. THIS PRIVATE KEY IS THE SAME AS YOUR MAINNET PRIVATE KEY.** 
+
+**If uploading to Github or using git version control in general it is good practice to protect yourself from uploading secrect keys to somewhere you don't want them. First of all the best way is to not upload your hardhat config file with your private key to your repo. You will get robbed.**
+
+Another way of protecting yourself and keeping `hardhat.config.js` in version control is to use dotenv.
+
+```bash
+npm install --save dotenv
+```
+
+Your hardhat.config.js file would look something like:
+
+```javascript
+require("@nomiclabs/hardhat-waffle");
+require("dotenv").config();
+
+module.exports = {
+  solidity: "0.8.0",
+  networks: {
+    rinkeby: {
+      url: process.env.STAGING_ALCHEMY_KEY,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+    mainnet: {
+      chainId: 1,
+      url: process.env.PROD_ALCHEMY_KEY,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+  },
+};
+```
+
+And your .env file would look something like:
+
+```
+STAGING_ALCHEMY_KEY=BLAHBLAH
+PROD_ALCHEMY_KEY=BLAHBLAH
+PRIVATE_KEY=BLAHBLAH
+```
+
+Be sure to have the .env in your .gitignore.
 
 You can grab your API URL from the Alchemy dashboard and paste that in. Then, you'll need your **private** rinkeby key (not your public address!) which you can grab from metamask and paste that in there as well.
 

--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_2_Deploy_To_Real_Testnet.md
@@ -62,7 +62,6 @@ For MyCrypto, you'll need to connect your wallet, make an account, and then clic
 | Name             | Link                                  | Amount          | Time         |
 | ---------------- | ------------------------------------- | --------------- | ------------ |
 | MyCrypto         | https://app.mycrypto.com/faucet       | 0.01            | None         |
-| Buildspace       | https://buildspace-faucet.vercel.app/ | 0.025           | 1d           |
 | Official Rinkeby | https://faucet.rinkeby.io/            | 3 / 7.5 / 18.75 | 8h / 1d / 3d |
 | Chainlink        | https://faucets.chain.link/rinkeby    | 0.1             | None         |
 
@@ -93,24 +92,26 @@ module.exports = {
 
 **Note: DON'T COMMIT THIS FILE TO GITHUB. IT HAS YOUR PRIVATE KEY. YOU WILL GET HACKED + ROBBED. THIS PRIVATE KEY IS THE SAME AS YOUR MAINNET PRIVATE KEY.** 
 
-**If uploading to Github or using git version control in general it is good practice to protect yourself from uploading secrect keys to somewhere you don't want them. First of all the best way is to not upload your hardhat config file with your private key to your repo. You will get robbed.**
+**If uploading to Github or using git version control in general it is good practice to protect yourself from uploading secrect keys to somewhere you don't want them. First of all the best way is to not upload your hardhat config file by adding it to .gitignore. **
 
-Another way of protecting yourself and keeping `hardhat.config.js` in version control is to use dotenv.
+Another way of protecting yourself and keeping `hardhat.config.js` secure is to use dotenv. Install it with:
 
 ```bash
 npm install --save dotenv
 ```
 
-Your hardhat.config.js file would look something like:
+Now we can update hardhat.config.js to use dotenv:
 
 ```javascript
 require("@nomiclabs/hardhat-waffle");
+// Import and configure dotenv
 require("dotenv").config();
 
 module.exports = {
   solidity: "0.8.0",
   networks: {
     rinkeby: {
+      // This value will be replaced on runtime
       url: process.env.STAGING_ALCHEMY_KEY,
       accounts: [process.env.PRIVATE_KEY],
     },
@@ -123,17 +124,16 @@ module.exports = {
 };
 ```
 
-And your .env file would look something like:
+In the root project folder, create a `.env` file and add your secrets. It should look like this:
 
 ```
-STAGING_ALCHEMY_KEY=BLAHBLAH
+STAGING_ALCHEMY_KEY=REPLACE_WITH_ACTUAL_ALCHEMY_URL
 PROD_ALCHEMY_KEY=BLAHBLAH
 PRIVATE_KEY=BLAHBLAH
 ```
+Finally, add `.env` to your `.gitignore` file so Git ignores it and your secrets don't leave your machine! If you're confused by any of this, just watch a YouTube video on it, it's easy stuff!
 
-Be sure to have the .env in your .gitignore.
-
-You can grab your API URL from the Alchemy dashboard and paste that in. Then, you'll need your **private** rinkeby key (not your public address!) which you can grab from metamask and paste that in there as well.
+Next, grab your API URL from the Alchemy dashboard and paste that in. Then, you'll need your **private** rinkeby key (not your public address!) which you can grab from metamask and paste that in there as well.
 
 **Note: Accessing your private key can be done by opening MetaMask, change the network to "Rinkeby Test Network" and then click the three dots and select "Account Details" > "Export Private Key"**
 


### PR DESCRIPTION
I feel this was too vague of what the solution is to not have users to submit their private information about their wallets online. It stated that it will be covered later but didn't state where. Brought the information forward from that location (still there as well) as it isn't unreasonable for people to be already using version control already on this project.