### PR TITLE
feat: add switch network button back.

### DIFF
--- a/Polygon_ENS/en/Section_4/Lesson_2_Show_Minted_Domains.md
+++ b/Polygon_ENS/en/Section_4/Lesson_2_Show_Minted_Domains.md
@@ -44,6 +44,7 @@ To actually call this, we’ll have to make some more changes to our `renderInpu
 			return (
 				<div className="connect-wallet-container">
 					<p>Please connect to Polygon Mumbai Testnet</p>
+					<button className='cta-button mint-button' onClick={switchNetwork}>Click here to switch</button>
 				</div>
 			);
 		}


### PR DESCRIPTION
I just finished the project and I found that there's a small piece of missing code in Section 4 `Show minted domains and update records` step.

<img width="1300" alt="Screen Shot 2022-03-07 at 12 50 03 AM" src="https://user-images.githubusercontent.com/11360957/156933742-a5d3bec6-13d7-4f1d-ac75-073563008cfa.png">



There should be a switch network button because it's just implement in the previous step named `Show the user their wallet and network` in the same section.  Just like this : 

<img width="1349" alt="Screen Shot 2022-03-07 at 12 49 16 AM" src="https://user-images.githubusercontent.com/11360957/156933749-ad050858-68b7-4959-b832-29b9dfded30f.png">




