### PR TITLE
Update Lesson_4_Let_Users_Vote_On_Proposals.md

### DIFF
--- a/JS_DAO/en/Section_3/Lesson_4_Let_Users_Vote_On_Proposals.md
+++ b/JS_DAO/en/Section_3/Lesson_4_Let_Users_Vote_On_Proposals.md
@@ -199,12 +199,12 @@ The next chunk of code is kinda massive lol. It deals with actually rendering th
 
 If you’re familiar with React/JS, you can easily look through it and figure out how it works yourself. If you don’t know React/JS super well, don’t worry. Just copy-paste it. No shame there!
 
-Go ahead and replace the contents of `if (hasClaimedNFT) { }` with the code [here](https://github.com/buildspace/buildspace-dao-final/blob/main/src/App.jsx#L205).
-
 Add the zero address import after your exising imports:
 ```jsx
 import { AddressZero } from "@ethersproject/constants";
 ```
+
+Go ahead and replace the contents of `if (hasClaimedNFT) { }` with the code [here](https://github.com/buildspace/buildspace-dao-final/blob/main/src/App.jsx#L205).
 
 When you check out your web app, you’ll see something like:
 

--- a/JS_DAO/en/Section_3/Lesson_4_Let_Users_Vote_On_Proposals.md
+++ b/JS_DAO/en/Section_3/Lesson_4_Let_Users_Vote_On_Proposals.md
@@ -201,6 +201,11 @@ If you’re familiar with React/JS, you can easily look through it and figure ou
 
 Go ahead and replace the contents of `if (hasClaimedNFT) { }` with the code [here](https://github.com/buildspace/buildspace-dao-final/blob/main/src/App.jsx#L205).
 
+Add the zero address import after your exising imports:
+```jsx
+import { AddressZero } from "@ethersproject/constants";
+```
+
 When you check out your web app, you’ll see something like:
 
 ![Untitled](https://i.imgur.com/Q5bzFWb.png)


### PR DESCRIPTION
When copying your code from the buildspace-dao-final repo to support the (against / abstain / for) form + voting calls, you reference the zero address variable, but there is no callout to add the corresponding import. See error message below:

failed to delegate tokens ReferenceError: AddressZero is not defined
    at onSubmit

This import should fix the issue.