### PR TITLE
fix anchor provider issue, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 .DS_Store?
+
+# IDE
+.idea/

--- a/Solana_And_Web3/en/Section_2/Lesson_2_Write_First_Solana_Program.md
+++ b/Solana_And_Web3/en/Section_2/Lesson_2_Write_First_Solana_Program.md
@@ -90,7 +90,7 @@ const anchor = require('@project-serum/anchor');
 const main = async() => {
   console.log("🚀 Starting test...")
 
-  anchor.setProvider(anchor.Provider.env());
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Myepicproject;
   const tx = await program.rpc.startStuffOff();
 
@@ -115,7 +115,7 @@ We can step line by line here. First off, the `runMain` thing is just some javas
 The real magic happens here:
 
 ```javascript
-anchor.setProvider(anchor.Provider.env());
+anchor.setProvider(anchor.AnchorProvider.env());
 const program = anchor.workspace.Myepicproject;
 const tx = await program.rpc.startStuffOff();
 ```

--- a/Solana_And_Web3/en/Section_2/Lesson_3_Store_Basic_Data.md
+++ b/Solana_And_Web3/en/Section_2/Lesson_3_Store_Basic_Data.md
@@ -133,7 +133,7 @@ const main = async() => {
   console.log("🚀 Starting test...")
 
   // Create and set the provider. We set it before but we needed to update it, so that it can communicate with our frontend!
-  const provider = anchor.Provider.env();
+  const provider = anchor.AnchorProvider.env();
   anchor.setProvider(provider);
 
   const program = anchor.workspace.Myepicproject;
@@ -284,7 +284,7 @@ const { SystemProgram } = anchor.web3;
 const main = async() => {
   console.log("🚀 Starting test...")
 
-  const provider = anchor.Provider.env();
+  const provider = anchor.AnchorProvider.env();
   anchor.setProvider(provider);
 
   const program = anchor.workspace.Myepicproject;

--- a/Solana_And_Web3/en/Section_2/Lesson_4_Store_Structs_On_Program.md
+++ b/Solana_And_Web3/en/Section_2/Lesson_4_Store_Structs_On_Program.md
@@ -108,7 +108,7 @@ const { SystemProgram } = anchor.web3;
 const main = async() => {
   console.log("🚀 Starting test...")
 
-  const provider = anchor.Provider.env();
+  const provider = anchor.AnchorProvider.env();
   anchor.setProvider(provider);
 
   const program = anchor.workspace.Myepicproject;


### PR DESCRIPTION
When using the `Provider` class here with `"@project-serum/anchor": "^0.24.2"`: 
```
// Create and set the provider. We set it before but we needed to update it, so that it can communicate with our frontend!
  const provider = anchor.AnchorProvider.env();
```

I receive this error:
```
Running test suite: "/path/to/myepicproject/Anchor.toml"

🚀 Starting test...
TypeError: Cannot read properties of undefined (reading 'env')
    at main (/path/to/myepicproject/tests/myepicproject.js:10:36)
```

Changing `Provider` to `AnchorProvider` fixes this issue.

Also add IntelliJ/Webstorm config files to `.gitignore` 