### PR TITLE
Notes on anchor test issues are added for Solana_And_Web3, section 2 …

### DIFF
--- a/Solana_And_Web3/en/Section_2/Lesson_1_Get_Local_Solana_Env_Running.md
+++ b/Solana_And_Web3/en/Section_2/Lesson_1_Get_Local_Solana_Env_Running.md
@@ -67,7 +67,7 @@ Again, the installation steps are pretty straight forward [here](https://docs.so
 
 *Note: Depending on your system — once you install Solana, it may output a message like "Please update your PATH environment variable" and it'll give you a line to copy and run. Go ahead and copy + run that command so your PATH gets setup properly.*
 
-Once you're done installing, run this to make sure stuff is working: 
+Once you're done installing, run this to make sure stuff is working:
 
 ```bash
 solana --version
@@ -115,13 +115,13 @@ dyld: Library not loaded: /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib
   Reason: image not found
 ```
 
-Now, go ahead and CONTROL + C to stop the validator. **We're never going to actually use `solana-test-validator` manually ourselves again.** The workflow we're going to follow will actually automatically run the validator in the background for us. I just wanted to show you it working so you can start getting an idea of how stuff is working magically as we move forward ;). 
+Now, go ahead and CONTROL + C to stop the validator. **We're never going to actually use `solana-test-validator` manually ourselves again.** The workflow we're going to follow will actually automatically run the validator in the background for us. I just wanted to show you it working so you can start getting an idea of how stuff is working magically as we move forward ;).
 
 ### ☕️ Install Node, NPM, and Mocha
 
 Pretty solid chance you already have Node and NPM. When I do `node --version` I get `v16.0.0`. The minimum version is `v11.0.0`. If you don't have node and NPM, get it [here](https://nodejs.org/en/download/).
 
-After that, be sure to install this thing called Mocha. It's a nice little testing framework to help us test our Solana programs. 
+After that, be sure to install this thing called Mocha. It's a nice little testing framework to help us test our Solana programs.
 
 ```bash
 npm install -g mocha
@@ -155,7 +155,7 @@ anchor --version
 
 If you got that working, nice, you have Anchor!!
 
-We'll also use Anchor's npm module and Solana Web3 JS — these both will help us connect our web app to our Solana program! 
+We'll also use Anchor's npm module and Solana Web3 JS — these both will help us connect our web app to our Solana program!
 
 ```bash
 npm install @project-serum/anchor @solana/web3.js
@@ -216,6 +216,8 @@ This may take a while the first time you run it! As long as you get the green wo
 ![Untitled](https://i.imgur.com/V35KchA.png)
 
 **Note: If you receive the message `node: --dns-result-order= is not allowed in NODE_OPTIONS` this mean you are on an older version of Node and technically, this didn't pass! Since I tested this all with Node v16.13.0 I would highly suggest you just upgrade to this version. Upgrading node is a pain, learn more here. I like using [nvm](https://heynode.com/tutorial/install-nodejs-locally-nvm/).**
+
+**Note: If you get this message `Error: Your configured rpc port: 8899 is already in use` and you do not have application which is listenning to port 8899, try to run `solana-test-validator`, and in the next terminal tab `anchor test --skip-local-validator`. It should run fine.**
 
 **Congrats you've successfully set up your Solana environment :).** It's been quite the journey, but, we made it fam.
 

--- a/Solana_And_Web3/en/Section_2/Lesson_2_Write_First_Solana_Program.md
+++ b/Solana_And_Web3/en/Section_2/Lesson_2_Write_First_Solana_Program.md
@@ -13,7 +13,7 @@ You'll see all the magic stuff Anchor has generated for us here.
 
 ### 👶 A basic program.
 
-Let's write our first Solana program! This Rust code is going to live in the `lib.rs` file. 
+Let's write our first Solana program! This Rust code is going to live in the `lib.rs` file.
 
 Here's what it looks like:
 
@@ -54,7 +54,7 @@ We'll cover this thing a little later. Basically, this is the "program id" and h
 
 This is how we tell our program, "Hey — everything in this little module below is our program that we want to create handlers for that other people can call". You'll see how this comes into play. But, essentially this lets us actually call our Solana program from our frontend via a fetch request. We'll be seeing this `#[blah]` syntax a few places.
 
-They're called [macros](http://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/book/first-edition/macros.html) — and they basically attach code to our module. It's sorta like "inheriting" a class. 
+They're called [macros](http://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/book/first-edition/macros.html) — and they basically attach code to our module. It's sorta like "inheriting" a class.
 
 ```rust
 pub mod myepicproject {
@@ -134,7 +134,7 @@ In `Anchor.toml` we want to change the `[scripts]` tags a little:
 
 ```
 [scripts]
-test = "node tests/myepicproject.js" 
+test = "node tests/myepicproject.js"
 ```
 
 **Keep everything else in `Anchor.toml` the same!**
@@ -153,6 +153,8 @@ Here's what I get near the bottom:
 ```
 
 *Note: If you are using VSCode, don't forget to **save** all the files you're changing before running `anchor test`! I personally ran into so many issues because I thought I saved the file, but in reality I didn't :(.*
+
+*Note: If you see this error `Attempt to load a program that does not exist`, you can do `solana address -k target/deploy/myepicproject-keypair.json` and replace with this address every occurency in `lib.rs`, `Anchor.toml`, and  `myepicproject.js`.*
 
 **BOOOOM. YOU DID IT.**
 


### PR DESCRIPTION
Hi! I encountered a couple of issues which are not covered in the sections. The first issue is concerned with `anchor test` not being able to start on port 8899, though it was free when I run `lsof`. The second is related to the program Id. It is hardcoded ion the page and I assume it should have been written that the address might be different from that on the page. 