### PR TITLE
Check for chain id only after we have the wallet address 

### DIFF
--- a/JS_DAO/en/Section_4/Lesson_1_Remove_Admin_Power_And_Basic_Errors.md
+++ b/JS_DAO/en/Section_4/Lesson_1_Remove_Admin_Power_And_Basic_Errors.md
@@ -79,7 +79,7 @@ const network = useNetwork();
 Next, add the following in your `App.jsx` file right under the `mintNft` function:
 
 ```jsx
-if (network?.[0].data.chain.id !== ChainId.Rinkeby) {
+if (address && (network?.[0].data.chain.id !== ChainId.Rinkeby)) {
   return (
     <div className="unsupported-network">
       <h2>Please connect to Rinkeby</h2>


### PR DESCRIPTION
On Replit if we don't check for the address, we get 
"Uncaught TypeError: Cannot read properties of undefined (reading 'id')"
because the chain is undefined.
Thanks for mehul shah for sharing this fix on Discord!