### PR TITLE
Add missing `const presale` when updating `getCandyMachineState`

### DIFF
--- a/Solana_NFTs/en/Section_3/Lesson_1_Call_Candy_Machine_From_App.md
+++ b/Solana_NFTs/en/Section_3/Lesson_1_Call_Candy_Machine_From_App.md
@@ -286,6 +286,11 @@ const CandyMachine({walletAddress}) => {
     const itemsRedeemed = candyMachine.itemsRedeemed.toNumber();
     const itemsRemaining = itemsAvailable - itemsRedeemed;
     const goLiveData = candyMachine.data.goLiveDate.toNumber();
+    const presale =
+      candyMachine.data.whitelistMintSettings &&
+      candyMachine.data.whitelistMintSettings.presale &&
+      (!candyMachine.data.goLiveDate ||
+        candyMachine.data.goLiveDate.toNumber() > new Date().getTime() / 1000);
   
     const goLiveDateTimeString = `${new Date(
       goLiveData * 1000


### PR DESCRIPTION
In this lesson we write `getCandyMachineState` twice - the first time just to fetch + log the data, the second time also to call `setCandyMachine`. In the second time the `const presale = ...` section was missing. We reference `presale` in `setCandyMachine`, so we need it in this function. This commit just copies the `const presale = ...` from the first version of the function to the second, fixing the error.