### PR TITLE
add symbol to json

### DIFF
--- a/Solana_NFTs/en/Section_2/Lesson_2_Setup_NFT_Assets.md
+++ b/Solana_NFTs/en/Section_2/Lesson_2_Setup_NFT_Assets.md
@@ -43,7 +43,7 @@ Let's copy paste the following into `0.json`:
 ```json
 {
   "name": "NAME_OF_NFT",
-  "symbol": "",
+  "symbol": "SYMBOL_OF_NFT",
   "image": "0.png",
   "properties": {
     "files": [


### PR DESCRIPTION
getting error `Error deploying config to Solana network. Error: Invalid config, there must be a symbol.` seems like the Symbol became mandatory