### PR TITLE
fix: adjust lessons 3 & 4 in solana-pay-store

### DIFF
--- a/Solana_Pay_Store/en/Section_2/Lesson_3_Turn_Transactions_to_Payments.md
+++ b/Solana_Pay_Store/en/Section_2/Lesson_3_Turn_Transactions_to_Payments.md
@@ -171,7 +171,7 @@ Here's my `orders.js` API endpoint file (inside the `pages/api` directory):
 ```jsx
 // This API endpoint will let users POST data to add records and GET to retrieve
 import orders from "./orders.json";
-import fs from "fs";
+import { writeFile } from "fs/promises";
 
 function get(req, res) {
   const { buyer } = req.query;
@@ -195,7 +195,7 @@ async function post(req, res) {
     // If this address has not purchased this item, add order to orders.json
     if (!orders.find((order) => order.buyer === newOrder.buyer.toString() && order.itemID === newOrder.itemID)) {
       orders.push(newOrder);
-      await fs.writeFileSync("./pages/api/orders.json", JSON.stringify(orders, null, 2));
+      await writeFile("./pages/api/orders.json", JSON.stringify(orders, null, 2));
       res.status(200).json(orders);
     } else {
       res.status(400).send("Order already exists");
@@ -250,7 +250,7 @@ import { findReference, FindReferenceError } from '@solana/pay';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { InfinitySpin } from 'react-loader-spinner';
 import IPFSDownload from './IpfsDownload';
-import { addOrder } from '../Lib/api';
+import { addOrder } from '../lib/api';
 
 const STATUS = {
   Initial: 'Initial',

--- a/Solana_Pay_Store/en/Section_2/Lesson_4_Read_From_Our_Database.md
+++ b/Solana_Pay_Store/en/Section_2/Lesson_4_Read_From_Our_Database.md
@@ -1,7 +1,7 @@
 Now that we're adding items to our orders "database", it would be nice if we used it lol.
 
 ### 👀 Check if they've purchased on load
-The flow for doing this is going to be very similar to `addOrder`. First, head back over to `Lib/api.js` and add this handler:
+The flow for doing this is going to be very similar to `addOrder`. First, head back over to `lib/api.js` and add this handler:
 ```jsx
 // Returns true if a given public key has purchased an item before
 export const hasPurchased = async (publicKey, itemID) => {
@@ -38,7 +38,7 @@ import { findReference, FindReferenceError } from '@solana/pay';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { InfinitySpin } from 'react-loader-spinner';
 import IPFSDownload from './IpfsDownload';
-import { addOrder, hasPurchased } from '../Lib/api';
+import { addOrder, hasPurchased } from '../lib/api';
 
 const STATUS = {
   Initial: 'Initial',
@@ -225,7 +225,7 @@ export default async function handler(req, res) {
 }
 ```
 
-We can't use `fetchProducts` because we're removing hashes from it. Add this final piece in  `Lib/api.js`:
+We can't use `fetchProducts` because we're removing hashes from it. Add this final piece in  `lib/api.js`:
 ```jsx
 export const fetchItem = async (itemID) => {
   const response = await fetch("../api/fetchItem", {


### PR DESCRIPTION
Mostly typo fixes, with one fix to use `fs/promises` (otherwise there is no reason to await:
1. Change references to `lib/` directory to all be lowercase
2. Change `await fs.writeFileSync` to `await writeFile`

