### PR TITLE
Update Lesson_2_Show_Minted_Domains.md

### DIFF
--- a/Polygon_ENS/en/Section_4/Lesson_2_Show_Minted_Domains.md
+++ b/Polygon_ENS/en/Section_4/Lesson_2_Show_Minted_Domains.md
@@ -72,11 +72,11 @@ To actually call this, we’ll have to make some more changes to our `renderInpu
           {/* If the editing variable is true, return the "Set record" and "Cancel" button */}
           {editing ? (
             <div className="button-container">
-              // This will call the updateDomain function we just made
+              {/* This will call the updateDomain function we just made */}
               <button className='cta-button mint-button' disabled={loading} onClick={updateDomain}>
                 Set record
               </button>  
-              // This will let us get out of editing mode by setting editing to false
+              {/* This will let us get out of editing mode by setting editing to false */}
               <button className='cta-button mint-button' onClick={() => {setEditing(false)}}>
                 Cancel
               </button>  


### PR DESCRIPTION
changed comments
    // This will call the updateDomain function we just made
    // If editing is not true, the mint button will be returned instead
to
    {/* This will call the updateDomain function we just made */}
    {/* If editing is not true, the mint button will be returned instead */}

as the comments are inside render functions and show on the page

n.b. the 2nd and 3rd forward slash + asterisk combos in this comment are showing up weird with the asterisks missing