### PR TITLE
changed the mint method to mintToSelf

### DIFF
--- a/JS_DAO/en/Section_3/Lesson_1_Deploy_ERC20_Contract.md
+++ b/JS_DAO/en/Section_3/Lesson_1_Deploy_ERC20_Contract.md
@@ -97,7 +97,7 @@ const token = sdk.getToken("INSERT_TOKEN_ADDRESS");
     // What's the max supply you want to set? 1,000,000 is a nice number!
     const amount = 0;
     // Interact with your deployed ERC-20 contract and mint the tokens!
-    await token.mint(amount);
+    await token.mintToSelf(amount);
     const totalSupply = await token.totalSupply();
 
     // Print out how many of our token's are out there now!


### PR DESCRIPTION
token.mint has been deprecated. the correct method now is mintToSelf.
link to the docs - https://portal.thirdweb.com/typescript/sdk.token.minttoself