### PR TITLE
Fixed a spacing typo and set the amount variable to the correct amount (when minting tokens)

### DIFF
--- a/JS_DAO/en/Section_3/Lesson_1_Deploy_ERC20_Contract.md
+++ b/JS_DAO/en/Section_3/Lesson_1_Deploy_ERC20_Contract.md
@@ -95,7 +95,7 @@ const token = sdk.getToken("INSERT_TOKEN_ADDRESS");
 (async () => {
   try {
     // What's the max supply you want to set? 1,000,000 is a nice number!
-    const amount = 0;
+    const amount = 1_000_000;
     // Interact with your deployed ERC-20 contract and mint the tokens!
     await token.mintToSelf(amount);
     const totalSupply = await token.totalSupply();
@@ -189,7 +189,7 @@ const token = sdk.getToken("INSERT_TOKEN_ADDRESS");
 
 This is a lot. But you’re a thirdweb pro now ezpz.
 
-First, you’ll see we need both `editionDrop` and `token` contractsbecause we will be interacting with both contracts.
+First, you’ll see we need both `editionDrop` and `token` contracts because we will be interacting with both contracts.
 
 We need to first grab holders of our NFT from the `editionDrop` and then mint them their token using functions on the `token`.
 


### PR DESCRIPTION
# These are some simple typos that I found while going through the JavaScript DAO Project

## Typo 1
The "amount" constant that stores the amount of ERC-20 tokens we will mint (in line 98) should be set to 1,000,000 instead of 0 to actually mint the tokens and to print the same result in the terminal as the one that is shown in the guide. 

For example, when I followed the instructions verbatim, this is what I got in the terminal:

<img width="497" alt="Screen Shot 2022-06-25 at 10 51 50 AM" src="https://user-images.githubusercontent.com/86082012/175781203-2cd965d5-84fc-4af9-b6c1-26370ad91247.png">

However, this is what you're supposed to get according to the guide:

<img width="616" alt="Screen Shot 2022-06-25 at 10 58 07 AM" src="https://user-images.githubusercontent.com/86082012/175781389-07940b79-8030-4db4-8552-ce465139c4cc.png">

## Typo 2

This is just a small one. In line 192, there should be a space between "contracts" and "because"

## Conclusion

Thank you for reading this PR. I'm really enjoying the project so far and I hope that I could help make it just a little better.

