### PR TITLE
[Solidity and Smart Contracts - Section 4 - Lesson 2] Fix typos

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_4/Lesson_2_Finalize_Celebrate.md
+++ b/Solidity_And_Smart_Contracts/en/Section_4/Lesson_2_Finalize_Celebrate.md
@@ -52,9 +52,9 @@ emit NewWave(msg.sender, block.timestamp, _message);
 
 At a basic level, events are messages our smart contracts throw out that we can capture on our client in real-time.
 
-Lets say I'm chilling on your website and I just have it open. While I'm doing this, your other friend Jeremy waves to you. Right now, the only way I'd see Jeremy's wave is if I refreshed my page. This seems bad. Wouldn't it be cool if I could know that that contract was updated and have my UI magically update?
+Let's say I'm chilling on your website and I just have it open. While I'm doing this, your other friend Jeremy waves to you. Right now, the only way I'd see Jeremy's wave is if I refreshed my page. This seems bad. Wouldn't it be cool if I could know that that contract was updated and have my UI magically update?
 
-Even now, it's kinda annoying when we ourselves submit a message, and then we have to wait for it to be mined and then refresh the page to see all the updated list of messages, right? Lets fix that.
+Even now, it's kinda annoying when we ourselves submit a message, and then we have to wait for it to be mined and then refresh the page to see all the updated list of messages, right? Let's fix that.
 
 Check out my code here where I updated `getAllWaves` in `App.js.` 
 


### PR DESCRIPTION
Fixing typos for Solidity and Smart Contracts, Section 4, Lesson 2.
"Let's" is short for "Let us".