### PR TITLE
 [NFT Collection - Section 1 - Lesson 4] Add license identifier

### DIFF
--- a/NFT_Collection/en/Section_1/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
+++ b/NFT_Collection/en/Section_1/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
@@ -3,6 +3,8 @@
 Now that we got all our scripts good to go and the basics down, we're going to mint some NFTs! Here's what my updated `MyEpicNFT.sol` looks like:
 
 ```solidity
+// SPDX-License-Identifier: UNLICENSED
+
 pragma solidity ^0.8.1;
 
 // We first import some OpenZeppelin Contracts.


### PR DESCRIPTION
## Description
VSCode was indicating an issue with the code:
> SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.

We need to add license identifier to the code block to fix the VSCode issue.

## Changes
- Add license identifier to fix issue

