### PR TITLE
Paraphrased work in web3 section

### DIFF
--- a/NFT_Collection/en/Section_0/Lesson_1_What_Are_We_Building.md
+++ b/NFT_Collection/en/Section_0/Lesson_1_What_Are_We_Building.md
@@ -74,7 +74,7 @@ At the very least, drop a ⭐ on the repo if you're feeling fancy!
 
 ## 🚨Curious about working in web3?
 
-We're partnered with a bunch of awesome web3 companies that want to hire people from the buildspace network. We got companies like OpenSea, Edge and Node, and Chainlink as partners. **Even if you're just curious**, click "Work in Web3" on the side-bar, fill out the form real quick, and check out the opportunities!!
+We're partnered with a bunch of awesome web3 companies that want to hire people from the buildspace network. We got companies like OpenSea, Edge and Node, and Chainlink as partners. **Even if you're just curious**, click "Work" on header, fill out the form real quick, and check out the opportunities!!
 
 Worst case scenario, you get to talk to some really cool people in web3 :).
 


### PR DESCRIPTION
Since the redesign of buildspace, the Work in Web3 Nav section was moved to the header from the side bar, noticed that it wasn't updated in the Mint NFT Collection.