### PR TITLE
removed semi-colon

### DIFF
--- a/NFT_Game/en/Section_3/Lesson_6_Building_Arena_Page.md
+++ b/NFT_Game/en/Section_3/Lesson_6_Building_Arena_Page.md
@@ -386,7 +386,7 @@ const Arena = ({ characterNFT, setCharacterNFT }) => {
               setCharacterNFT((prevState) => {
                   return { ...prevState, hp: playerHp };
               });
-            };
+            }
             /*
             * If player isn't ours, update boss Hp only
             */


### PR DESCRIPTION
semi-colon between close curly braces and else keyword. Can't see the whole thing in this view but it works out as 

    `}; else {`

instead of 

   ` } else {`