### PR TITLE
Fix: Issues with openssl-sys v0.9.72

### DIFF
--- a/Solana_And_Web3/en/Section_2/Resources/windows_setup.md
+++ b/Solana_And_Web3/en/Section_2/Resources/windows_setup.md
@@ -194,6 +194,20 @@ This command *can* fail if you don't have all the necessary dependencies. Run th
 sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y pkg-config build-essential libudev-dev
 ```
 
+If you're having issues with `openssl-sys v0.9.72` try running command below. This make sures the development packages of `openssl` are installed.
+
+If you're on Ubuntu:
+
+```bash
+sudo apt-get install libssl-dev
+```
+
+If you're on Fedora:
+
+```bash
+sudo apt-get install openssl-devel
+```
+
 Once this is done, you'll have **Anchor Version Manager** installed. Now we can actually install Anchor:
 
 ```bash


### PR DESCRIPTION
This fixes the issue with `openssl` by installing development packages of `openssl`.

Issue:
```error: failed to run custom build command for openssl-sys v0.9.72```

These are the required development packages:
- `libssl-dev` on Ubuntu
- `openssl-devel` on Fedora