### PR TITLE
[typo] Update to wording used in the image shown

### DIFF
--- a/JS_DAO/en/Section_3/Lesson_1_Deploy_ERC20_Contract.md
+++ b/JS_DAO/en/Section_3/Lesson_1_Deploy_ERC20_Contract.md
@@ -66,7 +66,7 @@ Boom! It deployed a fresh token contract. If you head to [`https://goerli.ethers
 
 You can even add your token to Metamask as a custom token.
 
-Just click “Import Token”:
+Just click “Import tokens”:
 
 ![Untitled](https://i.imgur.com/Bf56dyv.png)
 


### PR DESCRIPTION
The wording of the link for importing tokens in MetaMask seems to be `Import tokens`. 

<img width="821" alt="Screen Shot 2022-10-06 at 1 02 13" src="https://user-images.githubusercontent.com/3862661/194107636-eeb66fcf-aef5-4f16-a789-b4212a35d9c8.png">
