### PR TITLE
Add heading to divide content

### DIFF
--- a/Solana_And_Web3/en/Section_3/Lesson_2_Call_Deployed_Program.md
+++ b/Solana_And_Web3/en/Section_3/Lesson_2_Call_Deployed_Program.md
@@ -140,6 +140,8 @@ import { Buffer } from 'buffer';
 window.Buffer = Buffer;
 ```
 
+### 🧑‍🎄 Add `getProvider`
+
 Let's create a function called `getProvider`. Add this right below `onInputChange` . Here's the code below.
 
 ```javascript


### PR DESCRIPTION
The paragraph about adding `getProvider()` looked like it belonged to  Replit error content