### PR TITLE
Adjust web3 import references

### DIFF
--- a/Solana_Core/en/Core_1/Lesson_2_Reading_Data_From_The_Blockchain.md
+++ b/Solana_Core/en/Core_1/Lesson_2_Reading_Data_From_The_Blockchain.md
@@ -132,13 +132,13 @@ Now to use the key, we'll make a new connection to the JSON RPC. With the connec
 
 ```ts
   const addressSubmittedHandler = (address: string) => {
-    const key = new Web3.PublicKey(address);
+    const key = new web3.PublicKey(address);
     setAddress(key.toBase58())
 
-    const connection = new Web3.Connection(Web3.clusterApiUrl('devnet'))
+    const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
     
     connection.getBalance(key).then(balance => {
-      setBalance(balance / Web3.LAMPORTS_PER_SOL)
+      setBalance(balance / web3.LAMPORTS_PER_SOL)
     })
   }
 ```
@@ -156,10 +156,10 @@ This is pretty good, but if you mess up the address, you get a nasty error. Let'
   const addressSubmittedHandler = (address: string) => {
     try {
       setAddress(address)
-      const key = new Web3.PublicKey(address)
-      const connection = new Web3.Connection(Web3.clusterApiUrl('devnet'))
+      const key = new web3.PublicKey(address)
+      const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
       connection.getBalance(key).then(balance => {
-        setBalance(balance / Web3.LAMPORTS_PER_SOL)
+        setBalance(balance / web3.LAMPORTS_PER_SOL)
       })
     } catch (error) {
       setAddress('')


### PR DESCRIPTION
The instructions tell folks to import `* as web3` with a lowercase `w`. Later in the instructions, you switch to using a capital `W`. Pretty minor but for new developers this could be confusing.