### PR TITLE
Lesson 14 - metaplex nft fetching by owner

### DIFF
--- a/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
+++ b/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
@@ -86,7 +86,7 @@ Finally, we need to update the `return` statement to display the NFTs. We'll use
 ```tsx
   return (
      <div>
-      {nftData?.length && (
+      {nftData.length && (
         <div className={styles.gridNFT}>
           {nftData.map((nft, i) => (
             <div key={i} >

--- a/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
+++ b/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
@@ -17,7 +17,7 @@ The "Display NFT" page doesn't show anything yet - that's where you come in.
 Open up `src/components/FetchNFT.tsx` and let's get going. We'll start off with Metaplex setup at the top of the component:
 ```tsx
 export const FetchNft: FC = () => {
-  const [nftData, setNftData] = useState(null)
+  const [nftData, setNftData] = useState([])
 
   const { connection } = useConnection()
   const wallet = useWallet()
@@ -31,7 +31,7 @@ export const FetchNft: FC = () => {
 
 Looks familiar.
 
-Now let's fill in the `fetchNfts` function. We'll use the `findAllByOwner` method we saw earlier. We'll also need to use the `useWallet` hook to get the wallet address. 
+Now let's fill in the `fetchNfts` function. We'll use the `findAllByOwner` method we saw earlier. We'll also need to use the `useWallet` hook to get the wallet address.
 
 ```tsx
   const fetchNfts = async () => {
@@ -40,15 +40,20 @@ Now let's fill in the `fetchNfts` function. We'll use the `findAllByOwner` metho
     }
 
     // fetch NFTs for connected wallet
-    const nfts = await metaplex
+    const nftResults = await metaplex
       .nfts()
       .findAllByOwner({ owner: wallet.publicKey })
+      .run()
+
+    // some nfts may not have a uri to fetch metadata! get rid of em
+    const nftHasUri = nfts.filter((nft) => nft.uri)
 
     // fetch off chain metadata for each NFT
-    let nftData = []
-    for (let i = 0; i < nfts.length; i++) {
-      let fetchResult = await fetch(nfts[i].uri)
-      let json = await fetchResult.json()
+    const nftData = []
+    for (let i = 0; i < nftHasUri.length; i++) {
+      const { uri } = nftHasUri[i]
+      const data = await fetcher(uri)
+      const json = await data.json()
       nftData.push(json)
     }
 
@@ -80,13 +85,13 @@ Finally, we need to update the `return` statement to display the NFTs. We'll use
 
 ```tsx
   return (
-    <div>
-      {nftData && (
+     <div>
+      {nftData?.length && (
         <div className={styles.gridNFT}>
-          {nftData.map((nft) => (
-            <div>
+          {nftData.map((nft, i) => (
+            <div key={i} >
               <ul>{nft.name}</ul>
-              <img src={nft.image} />
+              <img alt={nft.name} src={nft.image} />
             </div>
           ))}
         </div>
@@ -101,4 +106,4 @@ We can now see our NFTs! 🎉 Here's what my wallet looks like 😆
 
 Back in the old days (circa Oct 2021) I had to do this all manually and I kept getting rate limited by the RPCs, so take a moment to be grateful to the Metaplex devs for this wonderful SDK!
 
-Play around with `nftData` here. Log it to the console and try displaying other values like symbol or description! Maybe add a filter so users can only display NFTs from a specific collection? 
+Play around with `nftData` here. Log it to the console and try displaying other values like symbol or description! Maybe add a filter so users can only display NFTs from a specific collection?


### PR DESCRIPTION
Fixes a bug in example with fetching of nft data.

- add `.run()` call for metaplex api
- response checks in place for data without uris
- refactors / small code improvements