### PR TITLE
Updated `candyMachines` to `candyMachinesV2`

### DIFF
--- a/Solana_Core/en/Core_2/Lesson_15_Display_NFTs_From_Candy_Machine.md
+++ b/Solana_Core/en/Core_2/Lesson_15_Display_NFTs_From_Candy_Machine.md
@@ -61,7 +61,7 @@ export const FetchCandyMachine: FC = () => {
     // fetch candymachine data
     try {
       const candyMachine = await metaplex
-        .candyMachines()
+        .candyMachinesV2()
         .findByAddress({ address: new PublicKey(candyMachineAddress) })
         .run()
 


### PR DESCRIPTION
`candyMachines` is for v1 and therefore doesnt work when we try to verify our own NFT mint from previous sections.