### PR TITLE
Update Discord channel to gtfol

### DIFF
--- a/Polygon_ENS/en/Section_0/Lesson_1_Lets_Make_Some_Domains.md
+++ b/Polygon_ENS/en/Section_0/Lesson_1_Lets_Make_Some_Domains.md
@@ -60,7 +60,7 @@ Let's get you some open-source rep!!!
 
 _Please do this else Raza will be sad :(_
 
-Hey! Go ahead and say gm in `#gm-only` on Discord. This is very important. Extremely important.
+Hey! Go ahead and say gm in `#gtfol` on Discord. This is very important. Extremely important.
 
 If you don't do this then all of humanity will collectively jump and disrupt the Earth's orbit causing it to collide with Venus.
 


### PR DESCRIPTION
The original `#gm-only` Discord channel no longer exists. Updating the guide to use `#gtfol` instead.