### PR TITLE
Fixed Minor Typo

### DIFF
--- a/Solana_Core/en/Core_3/Lesson_13_Build_NFT_Staking_Program.md
+++ b/Solana_Core/en/Core_3/Lesson_13_Build_NFT_Staking_Program.md
@@ -166,7 +166,7 @@ Notice how we have defined the variables in the `process_initialize_stake_accoun
 
 ```rust
 // state.rs
-use borsh:: { BorshSeralize, BorshDeserialize };
+use borsh:: { BorshSerialize, BorshDeserialize };
 use solana_program:: {
     program_pack::{ IsInitialized, Sealed },
     pubkey::Pubkey,


### PR DESCRIPTION
changed line 169
from: ```use borsh:: { BorshSeralize, BorshDeserialize };``` |  "BorshSeralize" is a typo
to: ```use borsh:: { BorshSerialize, BorshDeserialize };```