### PR TITLE
"below" should be more accurate.

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_2/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/en/Section_2/Lesson_4_Call_Deployed_Contract.md
@@ -13,7 +13,7 @@ So, our smart contract has this function that retrieves the total number of wave
 
 Lets call this function from our website :).
 
-Go ahead and write this function right under our `connectWallet()` function.
+Go ahead and write this function right below our `connectWallet()` function.
 
 ```javascript
 const wave = async () => {


### PR DESCRIPTION
"Go ahead and write this function right *under* our `connectWallet()` function." - might seem like the wave function has to be inside the connectWallet() function, instead of it being a seperate function.