### PR TITLE
Updated Solana Core / Core 2

### DIFF
--- a/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
+++ b/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
@@ -43,6 +43,7 @@ Now let's fill in the `fetchNfts` function. We'll use the `findAllByOwner` metho
     const nfts = await metaplex
       .nfts()
       .findAllByOwner({ owner: wallet.publicKey })
+      .run();
 
     // fetch off chain metadata for each NFT
     let nftData = []


### PR DESCRIPTION
Problem: Current code is broken since `nfts` is not an array, so you cant run `nfts.length`.
- Corrected code.