### PR TITLE
Update Solana Core / Core 2

### DIFF
--- a/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
+++ b/Solana_Core/en/Core_2/Lesson_14_Displaying_NFTs_from_Wallet.md
@@ -4,6 +4,7 @@ You know how it goes. Template time. However, as the things we're building get b
 git clone https://github.com/buildspace/solana-display-nfts-frontend
 cd solana-display-nfts-frontend
 git checkout starter
+npm install @metaplex-foundation/js@latest
 npm i
 npm run dev
 ```


### PR DESCRIPTION
Problem: Current code is broken since project comes with an outdated version of the library, this causes that the `nfts` variable is not an array, so you cant run `nfts.length`.

- Added instruction to almuni to update metaplex library.