### PR TITLE
Added cron job to remove stale PRs and issues

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,2 @@
+translation: ["**/cn/*", "**/es/*"]
+documentation: ["**/en/*"]

--- a/.github/workflows/inactivities.yml
+++ b/.github/workflows/inactivities.yml
@@ -1,0 +1,25 @@
+name: Close inactive issues and PRs
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v6
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is marked as stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR is marked as stale because it has been open for 30 days with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 14 days. Feel free to re-open it."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read # for TimonVS/pr-labeler-action to read config file
+      pull-requests: write # for TimonVS/pr-labeler-action to add labels in PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value


### PR DESCRIPTION
Workflow should automatically label PRs and issues as stale if there is no activity within 30 days and remove it after 14 days of no activity.