### PR TITLE
Fixed focusing out of currentWindow issue.

### DIFF
--- a/GPT3_Writer/en/Section_3/Lesson_3_Inject_into_webpage.md
+++ b/GPT3_Writer/en/Section_3/Lesson_3_Inject_into_webpage.md
@@ -24,7 +24,7 @@ Head back to your `contextMenuServiceWorker.js`  file and add a new function cal
 
 ```javascript
 const sendMessage = (content) => {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+  chrome.tabs.query({ url: "https://www.calmlywriter.com/online/" }, (tabs) => {
     const activeTab = tabs[0].id;
 
     chrome.tabs.sendMessage(


### PR DESCRIPTION
used the `url` parameter to point to the text-editor directly, `chrome.tabs.query({ url: "URL_of_your_text_editor" }, (tabs) => { const activeTab = tabs[0].id;` instead of the `chrome.tabs.query({ active: true, currentWindow: true }`.