### PR TITLE
Patch depreciated Body.buffer() method in Avatar Generator

### DIFF
--- a/AI_Avatar_Generator/en/Section_3/Lesson_2_Call_the_inference_API.md
+++ b/AI_Avatar_Generator/en/Section_3/Lesson_2_Call_the_inference_API.md
@@ -231,7 +231,7 @@ const generateAction = async (req, res) => {
 
   // Check for different statuses to send proper payload
   if (response.ok) {
-    const buffer = await response.buffer();
+    const buffer = await response.arrayBuffer();
     res.status(200).json({ image: buffer });
   } else if (response.status === 503) {
     const json = await response.json();
@@ -247,7 +247,7 @@ export default generateAction;
 
 This should be pretty self explanatory — we are checking for three different statuses: `ok`, `503`, and any other error! Let’s break these down a bit more:
 
-`ok` - Remember this is essentially any successful status code like a `200`. This means the call was a success and it should return back the image. Now the interesting part here is taking our response and converting it into a `buffer` . In order for us to set our image in our UI we will need to convert it into a form that our UI will be able to read. Let’s start with a buffer and see what happens :). 
+`ok` - Remember this is essentially any successful status code like a `200`. This means the call was a success and it should return back the image. Now the interesting part here is taking our response and converting it into an `arrayBuffer` . In order for us to set our image in our UI we will need to convert it into a form that our UI will be able to read. Let’s start with a an ArrayBuffer and see what happens :). 
 
 `503` - We will receive this when our model is still loading. This response will include two properties — `error` and `estimated_time` . `error` will just be a message stating what is happening and `estimated_time` is how much longer it may take to load the model. We will be using the `estimated_time` to setup a retry method soon so keep that in mind!
 
@@ -259,7 +259,7 @@ Write some prompt, press generate and let’s see what happens:
 
 ![https://hackmd.io/_uploads/SyARF64qo.png](https://hackmd.io/_uploads/SyARF64qo.png)
 
-Holy shit just like that and I received a response! You can see here that I responded with my buffer no problem! 
+Holy shit just like that and I received a response! You can see here that I responded with my ArrayBuffer no problem! 
 
 Now, let’s change the prompt a tad — woh we received a 503 😅. Looks like our model is still loading here:
 

--- a/AI_Avatar_Generator/en/Section_3/Lesson_3_Display_generated_images.md
+++ b/AI_Avatar_Generator/en/Section_3/Lesson_3_Display_generated_images.md
@@ -162,7 +162,7 @@ const bufferToBase64 = (buffer) => {
 };
 ```
 
-It’s a super simple function that takes in a `buffer` and adds some image decorators to it so our UI will know it’s an image!
+It’s a super simple function that takes in a `arrayBuffer` and adds some image decorators to it so our UI will know it’s an image!
 
 Now take that function and inside of our `generateAction` and add this function in the `ok` response:
 ```jsx
@@ -186,7 +186,7 @@ const generateAction = async (req, res) => {
   );
 
   if (response.ok) {
-    const buffer = await response.buffer();
+    const buffer = await response.arrayBuffer();
     // Convert to base64
     const base64 = bufferToBase64(buffer);
     // Make sure to change to base64

--- a/AI_Avatar_Generator/en/Section_3/Lesson_3_Display_generated_images.md
+++ b/AI_Avatar_Generator/en/Section_3/Lesson_3_Display_generated_images.md
@@ -148,13 +148,16 @@ LFG. We are ready to display some images, pretty freaking hype ngl. Let’s go a
 
 Wait… wtf? This image is broken AF lol. 
 
-There is actually 1 more thing we need to do in order to get this to work properly. If you remember from our API , we were returning a `buffer` to our frontend. Well, in order to display an image we need to convert that `buffer` into a `base64` string. This is the only way that our frontend will understand what as an image!
+There is actually 1 more thing we need to do in order to get this to work properly. If you remember from our API , we were returning an `ArrayBuffer` to our frontend. Well, in order to display an image we need to convert that `ArrayBuffer` into a `base64` string. This is the only way that our frontend will understand what as an image!
 
 For this, let’s had back to `generate.js` and we are going to create a new function called `bufferToBase64` :
 
 ```jsx
 const bufferToBase64 = (buffer) => {
-  const base64 = buffer.toString('base64');
+  let arr = new Uint8Array(buffer);
+  const base64 = btoa(
+    arr.reduce((data, byte) => data + String.fromCharCode(byte), '')
+  )
   return `data:image/png;base64,${base64}`;
 };
 ```


### PR DESCRIPTION
`.buffer()` is a depreciated method from earlier versions of node/node-fetch causing method not found errors. `.arrayBuffer()` is suitable for all versions. Have swapped out the body data conversion to ArrayBuffer & modified `bufferToBase64` function to correctly convert the ArrayBuffer to Base64 for display.