### PR TITLE
Fix: replacing 'now' to block.timestamp

### DIFF
--- a/NFT_Game/en/Section_2/Lesson_1_Build_Boss_And_Attack_Logic.md
+++ b/NFT_Game/en/Section_2/Lesson_1_Build_Boss_And_Attack_Logic.md
@@ -373,7 +373,7 @@ uint randNonce = 0; // this is used to help ensure that the algorithm has differ
 
 function randomInt(uint _modulus) internal returns(uint) {
    randNonce++;                                                     // increase nonce
-   return uint(keccak256(abi.encodePacked(now,                      // an alias for 'block.timestamp'
+   return uint(keccak256(abi.encodePacked(block.timestamp,         //  now timestamp
                                           msg.sender,               // your address
                                           randNonce))) % _modulus;  // modulo using the _modulus argument
  }


### PR DESCRIPTION
TypeError: "now" has been deprecated. Use "block.timestamp" instead.